### PR TITLE
fix(all): enable inlineSources in tsconfig to fix source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Description

Without the `inlineSources` option set to `true`, TypeScript generates source maps that depend on the existence of the original source files. We only wants to publish the js and d.ts files though. Therefore we should enable `inlineSources` by default to tell TypeScript to inline the source contents into the map files.

## Example Before-After Source Map

```diff
{
  "version": 3,
  "file": "async-value.js",
  "sourceRoot": "",
  "sources": ["../../src/feature-app-manager/async-value.ts"],
  "names": [],
  "mappings": ";;AAAA;IACC,oBACiB,OAAwB,EACjC,KAAc,EACd,KAAa;QAHrB,iBAMC;QALgB,YAAO,GAAP,OAAO,CAAiB;QACjC,UAAK,GAAL,KAAK,CAAS;QACd,UAAK,GAAL,KAAK,CAAQ;QAEpB,OAAO,CAAC,IAAI,CAAC,UAAA,GAAG,IAAI,OAAA,CAAC,KAAI,CAAC,KAAK,GAAG,GAAG,CAAC,EAAlB,CAAkB,CAAC,CAAC,KAAK,CAAC,UAAA,GAAG,IAAI,OAAA,CAAC,KAAI,CAAC,KAAK,GAAG,GAAG,CAAC,EAAlB,CAAkB,CAAC,CAAC;IAC1E,CAAC;IACF,iBAAC;AAAD,CAAC,AARD,IAQC;AARY,gCAAU",
+  "sourcesContent": [
+    "export class AsyncValue<TValue> {\n\tpublic constructor(\n\t\tpublic readonly promise: Promise<TValue>,\n\t\tpublic value?: TValue,\n\t\tpublic error?: Error\n\t) {\n\t\tpromise.then(val => (this.value = val)).catch(err => (this.error = err));\n\t}\n}\n"
+  ]
}
```

closes #115 