### PR TITLE
build(all): move outDir/rootDir to tsconfig.build.json

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "outDir": "lib",
+    "rootDir": "src"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  }
+  "include": ["src/**/*"]
 }

--- a/packages/history-service/tsconfig.build.json
+++ b/packages/history-service/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "outDir": "lib",
+    "rootDir": "src"
   }
 }

--- a/packages/history-service/tsconfig.json
+++ b/packages/history-service/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  }
+  "include": ["src/**/*"]
 }

--- a/packages/module-loader/tsconfig.build.json
+++ b/packages/module-loader/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "outDir": "lib",
+    "rootDir": "src"
   }
 }

--- a/packages/module-loader/tsconfig.json
+++ b/packages/module-loader/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  }
+  "include": ["src/**/*"]
 }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "outDir": "lib",
+    "rootDir": "src"
   }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  }
+  "include": ["src/**/*"]
 }

--- a/packages/server-renderer/tsconfig.build.json
+++ b/packages/server-renderer/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "outDir": "lib",
+    "rootDir": "src"
   }
 }

--- a/packages/server-renderer/tsconfig.json
+++ b/packages/server-renderer/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src"
-  }
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
The two config options are only relevant when emitting js files, which can only be done with the `tsconfig.build.json` files, where also the `paths` config option is reset. Setting the `rootDir` to `"src"` without also resetting the `paths` config leads to validation errors in VSCode for the `tsconfig.json` files.