### PR TITLE
fix(integration-tests): do not emit declaration files (to memory-fs)

### DIFF
--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "declaration": false
+  }
 }


### PR DESCRIPTION
First of all, we don't need them. And secondly, this reduces the webpack output when running the tests.

I would have liked to also reduce the stats that are printed, but because of the following bug, only one of the two bundled files is printed:
https://github.com/facebook/jest/issues/2441
Jest PR with a fix: https://github.com/facebook/jest/pull/6871

When the PR is merged, we could use this stats config for example:

```js
{
  all: false,
  assets: true,
  colors: true,
  timings: true
}
```