### PR TITLE
feat(core): make AsyncValue thenable

### DIFF
--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -67,7 +67,7 @@ describe('FeatureAppManager', () => {
 
       expect(spyConsoleInfo.mock.calls).toEqual([]);
 
-      await asyncFeatureAppDefinition.promise;
+      await asyncFeatureAppDefinition;
 
       expect(spyConsoleInfo.mock.calls).toEqual([
         [
@@ -84,7 +84,7 @@ describe('FeatureAppManager', () => {
       expect(asyncFeatureAppDefinition.value).toBeUndefined();
       expect(asyncFeatureAppDefinition.error).toBeUndefined();
 
-      const featureAppDefinition = await asyncFeatureAppDefinition.promise;
+      const featureAppDefinition = await asyncFeatureAppDefinition;
 
       expect(asyncFeatureAppDefinition.value).toBe(featureAppDefinition);
       expect(asyncFeatureAppDefinition.error).toBeUndefined();
@@ -112,7 +112,7 @@ describe('FeatureAppManager', () => {
           );
 
           await expect(
-            manager.getAsyncFeatureAppDefinition('/example.js').promise
+            manager.getAsyncFeatureAppDefinition('/example.js')
           ).rejects.toEqual(expectedError);
 
           expect(

--- a/packages/core/src/async-value.ts
+++ b/packages/core/src/async-value.ts
@@ -1,9 +1,12 @@
-export class AsyncValue<TValue> {
+export class AsyncValue<TValue> implements PromiseLike<TValue> {
+  public then: Promise<TValue>['then'];
+
   public constructor(
     public readonly promise: Promise<TValue>,
     public value?: TValue,
     public error?: Error
   ) {
+    this.then = promise.then.bind(promise) as Promise<TValue>['then'];
     promise.then(val => (this.value = val)).catch(err => (this.error = err));
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "exclude": ["**/lib/**", "**/node_modules/**"]
   },
   "rules": {
+    "await-promise": [true, "AsyncValue"],
     "no-default-export": false,
     "no-implicit-dependencies": true,
     "no-object-literal-type-assertion": false


### PR DESCRIPTION
When calling `getAsyncFeatureAppDefinition` in an async context it feels strange to have to await a special `promise` property and not beeing able to just await the function call.

Therefore make AsyncValue itself a thenable. This makes it possible to just
write `await manager.getAsyncFeatureAppDefinition('/example.js')`.