### PR TITLE
feat(core): retain FeatureApp type in FeatureAppDefinition

### DIFF
--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -41,8 +41,8 @@ export interface FeatureAppDefinition<
 
 export type ModuleLoader = (url: string) => Promise<unknown>;
 
-export interface FeatureAppScope<FeatureApp> {
-  readonly featureApp: FeatureApp;
+export interface FeatureAppScope<TFeatureApp> {
+  readonly featureApp: TFeatureApp;
 
   destroy(): void;
 }
@@ -56,10 +56,10 @@ export interface FeatureAppManagerLike {
     url: string
   ): AsyncValue<FeatureAppDefinition<unknown>>;
 
-  getFeatureAppScope<FeatureApp>(
-    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
+  getFeatureAppScope<TFeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
     idSpecifier?: string
-  ): FeatureAppScope<FeatureApp>;
+  ): FeatureAppScope<TFeatureApp>;
 
   preloadFeatureApp(url: string): Promise<void>;
   destroy(): void;
@@ -107,10 +107,10 @@ export class FeatureAppManager implements FeatureAppManagerLike {
     return asyncFeatureAppDefinition;
   }
 
-  public getFeatureAppScope<FeatureApp>(
-    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
+  public getFeatureAppScope<TFeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
     idSpecifier?: string
-  ): FeatureAppScope<FeatureApp> {
+  ): FeatureAppScope<TFeatureApp> {
     const {id: featureAppId} = featureAppDefinition;
     const featureAppScopeId = JSON.stringify({featureAppId, idSpecifier});
 
@@ -131,7 +131,7 @@ export class FeatureAppManager implements FeatureAppManagerLike {
       this.featureAppScopes.set(featureAppScopeId, featureAppScope);
     }
 
-    return featureAppScope as FeatureAppScope<FeatureApp>;
+    return featureAppScope as FeatureAppScope<TFeatureApp>;
   }
 
   public async preloadFeatureApp(url: string): Promise<void> {
@@ -197,11 +197,11 @@ export class FeatureAppManager implements FeatureAppManagerLike {
     );
   }
 
-  private createFeatureAppScope<FeatureApp>(
-    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
+  private createFeatureAppScope<TFeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
     idSpecifier: string | undefined,
     deleteFeatureAppScope: () => void
-  ): FeatureAppScope<FeatureApp> {
+  ): FeatureAppScope<TFeatureApp> {
     const {configs} = this.options;
     const config = configs && configs[featureAppDefinition.id];
 

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -41,8 +41,8 @@ export interface FeatureAppDefinition<
 
 export type ModuleLoader = (url: string) => Promise<unknown>;
 
-export interface FeatureAppScope {
-  readonly featureApp: unknown;
+export interface FeatureAppScope<FeatureApp> {
+  readonly featureApp: FeatureApp;
 
   destroy(): void;
 }
@@ -56,10 +56,10 @@ export interface FeatureAppManagerLike {
     url: string
   ): AsyncValue<FeatureAppDefinition<unknown>>;
 
-  getFeatureAppScope(
-    featureAppDefinition: FeatureAppDefinition<unknown>,
+  getFeatureAppScope<FeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
     idSpecifier?: string
-  ): FeatureAppScope;
+  ): FeatureAppScope<FeatureApp>;
 
   preloadFeatureApp(url: string): Promise<void>;
   destroy(): void;
@@ -85,7 +85,7 @@ export class FeatureAppManager implements FeatureAppManagerLike {
 
   private readonly featureAppScopes = new Map<
     FeatureAppScopeId,
-    FeatureAppScope
+    FeatureAppScope<unknown>
   >();
 
   public constructor(
@@ -107,10 +107,10 @@ export class FeatureAppManager implements FeatureAppManagerLike {
     return asyncFeatureAppDefinition;
   }
 
-  public getFeatureAppScope(
-    featureAppDefinition: FeatureAppDefinition<unknown>,
+  public getFeatureAppScope<FeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
     idSpecifier?: string
-  ): FeatureAppScope {
+  ): FeatureAppScope<FeatureApp> {
     const {id: featureAppId} = featureAppDefinition;
     const featureAppScopeId = JSON.stringify({featureAppId, idSpecifier});
 
@@ -131,7 +131,7 @@ export class FeatureAppManager implements FeatureAppManagerLike {
       this.featureAppScopes.set(featureAppScopeId, featureAppScope);
     }
 
-    return featureAppScope;
+    return featureAppScope as FeatureAppScope<FeatureApp>;
   }
 
   public async preloadFeatureApp(url: string): Promise<void> {
@@ -197,11 +197,11 @@ export class FeatureAppManager implements FeatureAppManagerLike {
     );
   }
 
-  private createFeatureAppScope(
-    featureAppDefinition: FeatureAppDefinition<unknown>,
+  private createFeatureAppScope<FeatureApp>(
+    featureAppDefinition: FeatureAppDefinition<FeatureApp>,
     idSpecifier: string | undefined,
     deleteFeatureAppScope: () => void
-  ): FeatureAppScope {
+  ): FeatureAppScope<FeatureApp> {
     const {configs} = this.options;
     const config = configs && configs[featureAppDefinition.id];
 

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -17,7 +17,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
   let mockManager: FeatureAppManagerLike;
   let mockGetFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
-  let mockFeatureAppScope: FeatureAppScope;
+  let mockFeatureAppScope: FeatureAppScope<unknown>;
   let spyConsoleError: jest.SpyInstance;
 
   beforeEach(() => {

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -13,7 +13,7 @@ describe('FeatureAppContainer', () => {
   let mockManager: FeatureAppManagerLike;
   let mockGetFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
-  let mockFeatureAppScope: FeatureAppScope;
+  let mockFeatureAppScope: FeatureAppScope<unknown>;
   let spyConsoleError: jest.SpyInstance;
 
   beforeEach(() => {

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -32,7 +32,7 @@ const inBrowser =
 export class FeatureAppContainer extends React.PureComponent<
   FeatureAppContainerProps
 > {
-  private readonly featureAppScope?: FeatureAppScope;
+  private readonly featureAppScope?: FeatureAppScope<unknown>;
   private readonly featureApp?: FeatureApp;
   private readonly containerRef = React.createRef<HTMLDivElement>();
 


### PR DESCRIPTION
The `featureAppDefinition` argument provided to `getFeatureAppDefinition`
knows the type of the `FeatureApp`. Retain this type information by
providing it to the returned `FeatureAppScope`.