### PR TITLE
feat(history-service): rename interface property and method argument

### DIFF
--- a/docs/guides/sharing-the-browser-history.md
+++ b/docs/guides/sharing-the-browser-history.md
@@ -157,7 +157,7 @@ registry.registerProviders(featureServiceDefinitions, 'acme:integrator');
 A root location transformer is an object exposing two functions,
 `getConsumerPathFromRootLocation` and `createRootLocation`. In the following
 example, each consumer location is encoded as its own query parameter, with the
-unique consumer ID used as parameter name:
+`consumerUid` used as parameter name:
 
 ```js
 import * as history from 'history';
@@ -165,19 +165,19 @@ import * as history from 'history';
 
 ```js
 const rootLocationTransformer = {
-  getConsumerPathFromRootLocation(rootLocation, consumerId) {
+  getConsumerPathFromRootLocation(rootLocation, consumerUid) {
     const searchParams = new URLSearchParams(rootLocation.search);
 
-    return searchParams.get(consumerId);
+    return searchParams.get(consumerUid);
   },
 
-  createRootLocation(consumerLocation, rootLocation, consumerId) {
+  createRootLocation(consumerLocation, rootLocation, consumerUid) {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {
-      searchParams.set(consumerId, history.createPath(consumerLocation));
+      searchParams.set(consumerUid, history.createPath(consumerLocation));
     } else {
-      searchParams.delete(consumerId);
+      searchParams.delete(consumerUid);
     }
 
     const {pathname, state} = rootLocation;

--- a/packages/demos/src/history-service/root-location-transformer.ts
+++ b/packages/demos/src/history-service/root-location-transformer.ts
@@ -2,19 +2,19 @@ import {RootLocationTransformer} from '@feature-hub/history-service';
 import {createPath} from 'history';
 
 export const rootLocationTransformer: RootLocationTransformer = {
-  getConsumerPathFromRootLocation: (rootLocation, consumerId) => {
+  getConsumerPathFromRootLocation: (rootLocation, consumerUid) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
-    return searchParams.get(consumerId) || undefined;
+    return searchParams.get(consumerUid) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
+  createRootLocation: (consumerLocation, rootLocation, consumerUid) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {
-      searchParams.set(consumerId, createPath(consumerLocation));
+      searchParams.set(consumerUid, createPath(consumerLocation));
     } else {
-      searchParams.delete(consumerId);
+      searchParams.delete(consumerUid);
     }
 
     const {pathname, state} = rootLocation;

--- a/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
+++ b/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
@@ -91,7 +91,7 @@ describe('#createRootLocationTransformer', () => {
       it('puts the location pathname and query params directly to the root location', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerId: 'test:pri'
+          primaryConsumerUid: 'test:pri'
         });
 
         const rootLocation = locationTransformer.createRootLocation(
@@ -109,7 +109,7 @@ describe('#createRootLocationTransformer', () => {
       it('removes undefined consumer locations from the query parameter', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerId: 'test:pri'
+          primaryConsumerUid: 'test:pri'
         });
 
         let rootLocation = locationTransformer.createRootLocation(
@@ -134,7 +134,7 @@ describe('#createRootLocationTransformer', () => {
         it('throws an error', () => {
           const locationTransformer = createRootLocationTransformer({
             consumerPathsQueryParamName: '---',
-            primaryConsumerId: 'test:pri'
+            primaryConsumerUid: 'test:pri'
           });
 
           expect(() =>
@@ -143,8 +143,10 @@ describe('#createRootLocationTransformer', () => {
               {pathname: '/'} as Location,
               'test:pri'
             )
-          ).toThrowErrorMatchingInlineSnapshot(
-            `"Primary consumer tried to set query parameter \\"---\\" which is reserverd for consumer paths."`
+          ).toThrowError(
+            new Error(
+              `Primary consumer tried to set query parameter "---" which is reserverd for consumer paths.`
+            )
           );
         });
       });
@@ -154,7 +156,7 @@ describe('#createRootLocationTransformer', () => {
       it('takes the pathname and query params of the primary consumer directly, and the pathname and query params of the other consumers encoded as a single query param, into the root location', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerId: 'test:pri'
+          primaryConsumerUid: 'test:pri'
         });
 
         let rootLocation = locationTransformer.createRootLocation(
@@ -204,7 +206,7 @@ describe('#createRootLocationTransformer', () => {
       it('returns the consumer-specific locations', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerId: 'test:pri'
+          primaryConsumerUid: 'test:pri'
         });
 
         const rootLocation = {
@@ -239,7 +241,7 @@ describe('#createRootLocationTransformer', () => {
       it('returns undefined for a non-primary consumer', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerId: 'test:pri'
+          primaryConsumerUid: 'test:pri'
         });
 
         const rootLocation = {

--- a/packages/history-service/src/__tests__/define-history-service.node.test.ts
+++ b/packages/history-service/src/__tests__/define-history-service.node.test.ts
@@ -96,7 +96,9 @@ describe('HistoryService#create (on Node.js)', () => {
     describe('when the server renderer provides no server request', () => {
       it('throws an error', () => {
         expect(() => createHistories(undefined)).toThrowError(
-          'Static history can not be created without a server request.'
+          new Error(
+            'Static history can not be created without a server request.'
+          )
         );
       });
     });
@@ -108,7 +110,7 @@ describe('HistoryService#create (on Node.js)', () => {
         );
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'createStaticHistory was called multiple times by the consumer "test:1". Returning the same history instance as before.'
+          'createStaticHistory was called multiple times by consumer "test:1". Returning the same history instance as before.'
         );
       });
     });

--- a/packages/history-service/src/__tests__/define-history-service.test.ts
+++ b/packages/history-service/src/__tests__/define-history-service.test.ts
@@ -127,7 +127,7 @@ describe('defineHistoryService', () => {
           );
 
           expect(consoleWarnSpy).toHaveBeenCalledWith(
-            'createBrowserHistory was called multiple times by the consumer "test:1". Returning the same history instance as before.'
+            'createBrowserHistory was called multiple times by consumer "test:1". Returning the same history instance as before.'
           );
         });
       });

--- a/packages/history-service/src/create-root-location-transformer.ts
+++ b/packages/history-service/src/create-root-location-transformer.ts
@@ -7,19 +7,19 @@ import {
 
 export interface RootLocationOptions {
   readonly consumerPathsQueryParamName: string;
-  readonly primaryConsumerId?: string;
+  readonly primaryConsumerUid?: string;
 }
 
 export interface RootLocationTransformer {
   getConsumerPathFromRootLocation(
     rootLocation: history.Location,
-    consumerId: string
+    consumerUid: string
   ): string | undefined;
 
   createRootLocation(
     consumerLocation: history.Location | undefined,
     rootLocation: history.Location,
-    consumerId: string
+    consumerUid: string
   ): history.LocationDescriptorObject;
 }
 
@@ -60,7 +60,7 @@ function createRootLocationForPrimaryConsumer(
 function createRootLocationForOtherConsumer(
   rootLocation: history.Location,
   consumerLocation: history.Location | undefined,
-  consumerId: string,
+  consumerUid: string,
   consumerPathsQueryParamName: string
 ): history.LocationDescriptorObject {
   const allSearchParams = createSearchParams(rootLocation);
@@ -69,10 +69,10 @@ function createRootLocationForOtherConsumer(
   const newConsumerPaths = consumerLocation
     ? addConsumerPath(
         consumerPaths,
-        consumerId,
+        consumerUid,
         history.createPath(consumerLocation)
       )
-    : removeConsumerPath(consumerPaths, consumerId);
+    : removeConsumerPath(consumerPaths, consumerUid);
 
   if (newConsumerPaths) {
     allSearchParams.set(consumerPathsQueryParamName, newConsumerPaths);
@@ -98,10 +98,10 @@ export function createRootLocationTransformer(
   return {
     getConsumerPathFromRootLocation: (
       rootLocation: history.Location,
-      consumerId: string
+      consumerUid: string
     ): string | undefined => {
-      const {consumerPathsQueryParamName, primaryConsumerId} = options;
-      const isPrimaryConsumer = consumerId === primaryConsumerId;
+      const {consumerPathsQueryParamName, primaryConsumerUid} = options;
+      const isPrimaryConsumer = consumerUid === primaryConsumerUid;
       const searchParams = createSearchParams(rootLocation);
 
       if (isPrimaryConsumer) {
@@ -118,17 +118,17 @@ export function createRootLocationTransformer(
           return undefined;
         }
 
-        return getConsumerPath(consumerPaths, consumerId);
+        return getConsumerPath(consumerPaths, consumerUid);
       }
     },
 
     createRootLocation: (
       consumerLocation: history.Location | undefined,
       rootLocation: history.Location,
-      consumerId: string
+      consumerUid: string
     ): history.LocationDescriptorObject => {
-      const {consumerPathsQueryParamName, primaryConsumerId} = options;
-      const isPrimaryConsumer = consumerId === primaryConsumerId;
+      const {consumerPathsQueryParamName, primaryConsumerUid} = options;
+      const isPrimaryConsumer = consumerUid === primaryConsumerUid;
 
       if (isPrimaryConsumer) {
         return createRootLocationForPrimaryConsumer(
@@ -140,7 +140,7 @@ export function createRootLocationTransformer(
         return createRootLocationForOtherConsumer(
           rootLocation,
           consumerLocation,
-          consumerId,
+          consumerUid,
           consumerPathsQueryParamName
         );
       }

--- a/packages/history-service/src/history-service-v1.ts
+++ b/packages/history-service/src/history-service-v1.ts
@@ -14,7 +14,7 @@ export interface HistoryServiceV1 {
 export function createHistoryServiceV1Binder(
   historyMultiplexers: HistoryMultiplexers
 ): FeatureServiceBinder<HistoryServiceV1> {
-  return (consumerId: string): FeatureServiceBinding<HistoryServiceV1> => {
+  return (consumerUid: string): FeatureServiceBinding<HistoryServiceV1> => {
     let browserConsumerHistory: BrowserConsumerHistory | undefined;
     let staticConsumerHistory: history.History | undefined;
 
@@ -22,13 +22,13 @@ export function createHistoryServiceV1Binder(
       createBrowserHistory: () => {
         if (browserConsumerHistory) {
           console.warn(
-            `createBrowserHistory was called multiple times by the consumer ${JSON.stringify(
-              consumerId
+            `createBrowserHistory was called multiple times by consumer ${JSON.stringify(
+              consumerUid
             )}. Returning the same history instance as before.`
           );
         } else {
           browserConsumerHistory = new BrowserConsumerHistory(
-            consumerId,
+            consumerUid,
             historyMultiplexers.browserHistoryMultiplexer
           );
         }
@@ -39,13 +39,13 @@ export function createHistoryServiceV1Binder(
       createStaticHistory: () => {
         if (staticConsumerHistory) {
           console.warn(
-            `createStaticHistory was called multiple times by the consumer ${JSON.stringify(
-              consumerId
+            `createStaticHistory was called multiple times by consumer ${JSON.stringify(
+              consumerUid
             )}. Returning the same history instance as before.`
           );
         } else {
           staticConsumerHistory = new StaticConsumerHistory(
-            consumerId,
+            consumerUid,
             historyMultiplexers.staticHistoryMultiplexer
           );
         }

--- a/packages/history-service/src/internal/browser-consumer-history.ts
+++ b/packages/history-service/src/internal/browser-consumer-history.ts
@@ -9,10 +9,10 @@ export class BrowserConsumerHistory extends ConsumerHistory {
   private readonly browserUnregister: () => void;
 
   public constructor(
-    consumerId: string,
+    consumerUid: string,
     historyMultiplexer: HistoryMultiplexer
   ) {
-    super(consumerId, historyMultiplexer);
+    super(consumerUid, historyMultiplexer);
 
     this.browserUnregister = historyMultiplexer.listenForPop(() => {
       this.handlePop();
@@ -22,7 +22,7 @@ export class BrowserConsumerHistory extends ConsumerHistory {
   public destroy(): void {
     this.browserUnregister();
     this.unregisterCallbacks.forEach(unregister => unregister());
-    this.historyMultiplexer.replace(this.consumerId, undefined);
+    this.historyMultiplexer.replace(this.consumerUid, undefined);
   }
 
   public listen(
@@ -63,7 +63,7 @@ export class BrowserConsumerHistory extends ConsumerHistory {
 
   private handlePop(): void {
     const location = this.historyMultiplexer.getConsumerLocation(
-      this.consumerId
+      this.consumerUid
     );
 
     if (this.matches(location)) {

--- a/packages/history-service/src/internal/consumer-history.ts
+++ b/packages/history-service/src/internal/consumer-history.ts
@@ -6,11 +6,11 @@ export abstract class ConsumerHistory implements history.History {
   public location: history.Location;
 
   public constructor(
-    protected readonly consumerId: string,
+    protected readonly consumerUid: string,
     protected readonly historyMultiplexer: HistoryMultiplexer
   ) {
     this.location = history.createLocation(
-      historyMultiplexer.getConsumerLocation(consumerId),
+      historyMultiplexer.getConsumerLocation(consumerUid),
       undefined,
       undefined,
       history.createLocation('/')
@@ -36,7 +36,7 @@ export abstract class ConsumerHistory implements history.History {
       this.location
     );
 
-    this.historyMultiplexer.push(this.consumerId, this.location);
+    this.historyMultiplexer.push(this.consumerUid, this.location);
     this.action = 'PUSH';
   }
 
@@ -51,7 +51,7 @@ export abstract class ConsumerHistory implements history.History {
       this.location
     );
 
-    this.historyMultiplexer.replace(this.consumerId, this.location);
+    this.historyMultiplexer.replace(this.consumerUid, this.location);
     this.action = 'REPLACE';
   }
 
@@ -75,7 +75,7 @@ export abstract class ConsumerHistory implements history.History {
 
   public createHref(location: history.LocationDescriptorObject): history.Href {
     return this.historyMultiplexer.createHref(
-      this.consumerId,
+      this.consumerUid,
       history.createLocation(location, undefined, undefined, this.location)
     );
   }

--- a/packages/history-service/src/internal/consumer-paths.ts
+++ b/packages/history-service/src/internal/consumer-paths.ts
@@ -1,5 +1,5 @@
 export interface ConsumerPaths {
-  readonly [consumerId: string]: string;
+  readonly [consumerUid: string]: string;
 }
 
 function encodeConsumerPaths(consumerPaths: ConsumerPaths): string {
@@ -12,25 +12,25 @@ function decodeConsumerPaths(encodedConsumerPaths: string): ConsumerPaths {
 
 export function addConsumerPath(
   encodedConsumerPaths: string | null,
-  consumerId: string,
+  consumerUid: string,
   path: string
 ): string {
   return encodeConsumerPaths({
     ...decodeConsumerPaths(encodedConsumerPaths || '{}'),
-    [consumerId]: path
+    [consumerUid]: path
   });
 }
 
 export function removeConsumerPath(
   encodedConsumerPaths: string | null,
-  consumerId: string
+  consumerUid: string
 ): string | undefined {
   if (!encodedConsumerPaths) {
     return undefined;
   }
 
   /* istanbul ignore next */
-  const {[consumerId]: _removed, ...rest} = decodeConsumerPaths(
+  const {[consumerUid]: _removed, ...rest} = decodeConsumerPaths(
     encodedConsumerPaths
   );
 
@@ -43,7 +43,7 @@ export function removeConsumerPath(
 
 export function getConsumerPath(
   encodedConsumerPaths: string,
-  consumerId: string
+  consumerUid: string
 ): string {
-  return decodeConsumerPaths(encodedConsumerPaths)[consumerId];
+  return decodeConsumerPaths(encodedConsumerPaths)[consumerUid];
 }

--- a/packages/history-service/src/internal/history-multiplexer.ts
+++ b/packages/history-service/src/internal/history-multiplexer.ts
@@ -2,7 +2,7 @@ import * as history from 'history';
 import {RootLocationTransformer} from '../create-root-location-transformer';
 
 export interface ConsumerHistoryStates {
-  readonly [consumerId: string]: unknown;
+  readonly [consumerUid: string]: unknown;
 }
 
 export type RootLocation = history.Location<ConsumerHistoryStates>;
@@ -31,39 +31,39 @@ export class HistoryMultiplexer {
     return this.rootHistory.location;
   }
 
-  public push(consumerId: string, consumerLocation: history.Location): void {
+  public push(consumerUid: string, consumerLocation: history.Location): void {
     this.rootHistory.push(
-      this.createRootLocation(consumerId, consumerLocation)
+      this.createRootLocation(consumerUid, consumerLocation)
     );
   }
 
   public replace(
-    consumerId: string,
+    consumerUid: string,
     consumerLocation: history.Location | undefined
   ): void {
     this.rootHistory.replace(
-      this.createRootLocation(consumerId, consumerLocation)
+      this.createRootLocation(consumerUid, consumerLocation)
     );
   }
 
   public createHref(
-    consumerId: string,
+    consumerUid: string,
     consumerLocation: history.Location
   ): history.Href {
     return this.rootHistory.createHref(
-      this.createRootLocation(consumerId, consumerLocation)
+      this.createRootLocation(consumerUid, consumerLocation)
     );
   }
 
-  public getConsumerLocation(consumerId: string): history.Location {
+  public getConsumerLocation(consumerUid: string): history.Location {
     const consumerPath =
       this.rootLocationTransformer.getConsumerPathFromRootLocation(
         this.rootHistory.location,
-        consumerId
+        consumerUid
       ) || '/';
 
     const consumerStates = this.rootHistory.location.state;
-    const consumerState = consumerStates && consumerStates[consumerId];
+    const consumerState = consumerStates && consumerStates[consumerUid];
 
     return history.createLocation(consumerPath, consumerState);
   }
@@ -77,13 +77,13 @@ export class HistoryMultiplexer {
   }
 
   private createRootLocation(
-    consumerId: string,
+    consumerUid: string,
     consumerLocation: history.Location | undefined
   ): history.Location {
     const rootLocation = this.rootLocationTransformer.createRootLocation(
       consumerLocation,
       this.rootHistory.location,
-      consumerId
+      consumerUid
     );
 
     const consumerStates = this.rootHistory.location.state;
@@ -91,7 +91,7 @@ export class HistoryMultiplexer {
 
     const newConsumerStates: ConsumerHistoryStates = {
       ...consumerStates,
-      [consumerId]: consumerState
+      [consumerUid]: consumerState
     };
 
     return history.createLocation({...rootLocation, state: newConsumerStates});

--- a/packages/history-service/src/internal/test-root-location-transformer.ts
+++ b/packages/history-service/src/internal/test-root-location-transformer.ts
@@ -2,19 +2,19 @@ import * as history from 'history';
 import {RootLocationTransformer} from '../create-root-location-transformer';
 
 export const testRootLocationTransformer: RootLocationTransformer = {
-  getConsumerPathFromRootLocation: (rootLocation, consumerId) => {
+  getConsumerPathFromRootLocation: (rootLocation, consumerUid) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
-    return searchParams.get(consumerId) || undefined;
+    return searchParams.get(consumerUid) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
+  createRootLocation: (consumerLocation, rootLocation, consumerUid) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {
-      searchParams.set(consumerId, history.createPath(consumerLocation));
+      searchParams.set(consumerUid, history.createPath(consumerLocation));
     } else {
-      searchParams.delete(consumerId);
+      searchParams.delete(consumerUid);
     }
 
     return {


### PR DESCRIPTION
- Renamed the `primaryConsumerId` property of the `RootLocationOptions` interface to `primaryConsumerUid`.
- Renamed the `consumerId` method argument to `consumerUid`.