### PR TITLE
feat(all): rename manager/registry to featureAppManager/featureServiceRegistry

### DIFF
--- a/docs/guides/integrating-the-feature-hub.md
+++ b/docs/guides/integrating-the-feature-hub.md
@@ -30,16 +30,19 @@ import {someFeatureServiceDefinition2} from './some-feature-service-2';
 ```
 
 ```js
-const registry = new FeatureServiceRegistry();
+const featureServiceRegistry = new FeatureServiceRegistry();
 
 const featureServiceDefinitions = [
   someFeatureServiceDefinition1,
   someFeatureServiceDefinition2
 ];
 
-registry.registerFeatureServices(featureServiceDefinitions, 'acme:integrator');
+featureServiceRegistry.registerFeatureServices(
+  featureServiceDefinitions,
+  'acme:integrator'
+);
 
-const manager = new FeatureAppManager(registry);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry);
 ```
 
 **Note:** The integrator needs a self-selected but unique consumer ID to
@@ -64,7 +67,9 @@ import {loadAmdModule} from '@feature-hub/module-loader-amd';
 ```
 
 ```js
-const manager = new FeatureAppManager(registry, {moduleLoader: loadAmdModule});
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule
+});
 ```
 
 On the server:
@@ -74,7 +79,7 @@ import {loadCommonJsModule} from '@feature-hub/module-loader-commonjs';
 ```
 
 ```js
-const manager = new FeatureAppManager(registry, {
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
   moduleLoader: loadCommonJsModule
 });
 ```
@@ -103,7 +108,7 @@ import {FeatureAppLoader} from '@feature-hub/react';
 
 ```jsx
 <FeatureAppLoader
-  manager={manager}
+  featureAppManager={featureAppManager}
   src="https://example.com/some-feature-app.js"
 />
 ```
@@ -118,7 +123,7 @@ Additionally, when a Feature App needs to be rendered on the server, its
 
 ```jsx
 <FeatureAppLoader
-  manager={manager}
+  featureAppManager={featureAppManager}
   src="https://example.com/some-feature-app.js"
   serverSrc="https://example.com/some-feature-app-node.js"
 />
@@ -134,7 +139,7 @@ You can also define a `css` prop to add stylesheets to the document:
 
 ```jsx
 <FeatureAppLoader
-  manager={manager}
+  featureAppManager={featureAppManager}
   src="https://example.com/some-feature-app.js"
   css={[
     {href: 'https://example.com/some-feature-app.css'},
@@ -153,14 +158,14 @@ integrator:
 <section>
   <div>
     <FeatureAppLoader
-      manager={manager}
+      featureAppManager={featureAppManager}
       src="https://example.com/some-feature-app.js"
       idSpecifier="main"
     />
   </div>
   <aside>
     <FeatureAppLoader
-      manager={manager}
+      featureAppManager={featureAppManager}
       src="https://example.com/some-feature-app.js"
       idSpecifier="aside"
     />
@@ -185,7 +190,7 @@ import {someFeatureAppDefinition} from './some-feature-app';
 
 ```jsx
 <FeatureAppContainer
-  manager={manager}
+  featureAppManager={featureAppManager}
   featureAppDefinition={someFeatureAppDefinition}
 />
 ```
@@ -200,14 +205,14 @@ integrator:
 <section>
   <div>
     <FeatureAppContainer
-      manager={manager}
+      featureAppManager={featureAppManager}
       featureAppDefinition={someFeatureAppDefinition}
       idSpecifier="main"
     />
   </div>
   <aside>
     <FeatureAppContainer
-      manager={manager}
+      featureAppManager={featureAppManager}
       featureAppDefinition={someFeatureAppDefinition}
       idSpecifier="aside"
     />
@@ -225,8 +230,13 @@ associated with their respective IDs, via the `FeatureServiceRegistry` and
 const featureServiceConfigs = {'acme:some-feature-service': {foo: 'bar'}};
 const featureAppConfigs = {'acme:some-feature-app': {baz: 'qux'}};
 
-const registry = new FeatureServiceRegistry({configs: featureServiceConfigs});
-const manager = new FeatureAppManager(registry, {configs: featureAppConfigs});
+const featureServiceRegistry = new FeatureServiceRegistry({
+  configs: featureServiceConfigs
+});
+
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  configs: featureAppConfigs
+});
 ```
 
 Feature Services and Feature Apps can then use their respective config object as
@@ -279,19 +289,22 @@ const integratorDefinition = {
   }
 };
 
-const registry = new FeatureServiceRegistry();
+const featureServiceRegistry = new FeatureServiceRegistry();
 
 const featureServiceDefinitions = [
   someFeatureServiceDefinition1,
   someFeatureServiceDefinition2
 ];
 
-registry.registerFeatureServices(
+featureServiceRegistry.registerFeatureServices(
   featureServiceDefinitions,
   integratorDefinition.id
 );
 
-const {featureServices} = registry.bindFeatureServices(integratorDefinition);
+const {featureServices} = featureServiceRegistry.bindFeatureServices(
+  integratorDefinition
+);
+
 const someFeatureService2 = featureServices[someFeatureServiceDefinition2.id];
 
 someFeatureService2.foo(42);

--- a/docs/guides/sharing-npm-dependencies.md
+++ b/docs/guides/sharing-npm-dependencies.md
@@ -17,7 +17,9 @@ import Loadable from 'react-loadable';
 ```js
 defineExternals({react: React, 'react-loadable': Loadable});
 
-const manager = new FeatureAppManager(registry, {moduleLoader: loadAmdModule});
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule
+});
 ```
 
 Feature Apps should define these externals in their build config. For example,

--- a/docs/guides/sharing-the-browser-history.md
+++ b/docs/guides/sharing-the-browser-history.md
@@ -115,7 +115,7 @@ import {
 ```
 
 ```js
-const registry = new FeatureServiceRegistry();
+const featureServiceRegistry = new FeatureServiceRegistry();
 
 const rootLocationTransformer = createRootLocationTransformer({
   consumerPathsQueryParamName: '---'
@@ -126,7 +126,10 @@ const featureServiceDefinitions = [
   defineHistoryService(rootLocationTransformer)
 ];
 
-registry.registerFeatureServices(featureServiceDefinitions, 'acme:integrator');
+featureServiceRegistry.registerFeatureServices(
+  featureServiceDefinitions,
+  'acme:integrator'
+);
 ```
 
 On the server, the integrator defines the Async SSR Manager using the request.
@@ -134,7 +137,7 @@ The History Service depends on the Async SSR Manager to obtain its request and
 use it for the initial history location:
 
 ```js
-const registry = new FeatureServiceRegistry();
+const featureServiceRegistry = new FeatureServiceRegistry();
 
 const rootLocationTransformer = createRootLocationTransformer({
   consumerPathsQueryParamName: '---'
@@ -149,7 +152,10 @@ const featureServiceDefinitions = [
   defineHistoryService(rootLocationTransformer)
 ];
 
-registry.registerFeatureServices(featureServiceDefinitions, 'acme:integrator');
+featureServiceRegistry.registerFeatureServices(
+  featureServiceDefinitions,
+  'acme:integrator'
+);
 ```
 
 ## Root Location Transformer

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -14,7 +14,7 @@ interface MockFeatureServiceRegistry extends FeatureServiceRegistryLike {
 }
 
 describe('FeatureAppManager', () => {
-  let manager: FeatureAppManagerLike;
+  let featureAppManager: FeatureAppManagerLike;
   let mockRegistry: MockFeatureServiceRegistry;
   let mockFeatureServicesBinding: FeatureServicesBinding;
   let mockFeatureServicesBindingUnbind: () => void;
@@ -43,7 +43,7 @@ describe('FeatureAppManager', () => {
     mockFeatureAppDefinition = {create: mockFeatureAppCreate, id: 'testId'};
     mockFeatureAppModule = {default: mockFeatureAppDefinition};
     mockModuleLoader = jest.fn(async () => mockFeatureAppModule);
-    manager = new FeatureAppManager(mockRegistry);
+    featureAppManager = new FeatureAppManager(mockRegistry);
 
     spyConsoleInfo = jest.spyOn(console, 'info');
     spyConsoleInfo.mockImplementation(jest.fn());
@@ -55,13 +55,13 @@ describe('FeatureAppManager', () => {
 
   describe('#getAsyncFeatureAppDefinition', () => {
     beforeEach(() => {
-      manager = new FeatureAppManager(mockRegistry, {
+      featureAppManager = new FeatureAppManager(mockRegistry, {
         moduleLoader: mockModuleLoader
       });
     });
 
     it('logs an info message when the Feature App module was loaded', async () => {
-      const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(
+      const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
         '/example.js'
       );
 
@@ -77,7 +77,7 @@ describe('FeatureAppManager', () => {
     });
 
     it('returns an async value for a Feature App definition', async () => {
-      const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(
+      const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
         '/example.js'
       );
 
@@ -112,33 +112,34 @@ describe('FeatureAppManager', () => {
           );
 
           await expect(
-            manager.getAsyncFeatureAppDefinition('/example.js').promise
+            featureAppManager.getAsyncFeatureAppDefinition('/example.js')
+              .promise
           ).rejects.toEqual(expectedError);
 
           expect(
-            manager.getAsyncFeatureAppDefinition('/example.js').error
+            featureAppManager.getAsyncFeatureAppDefinition('/example.js').error
           ).toEqual(expectedError);
         });
       });
 
       it('throws an error if no module loader was provided', () => {
-        manager = new FeatureAppManager(mockRegistry);
+        featureAppManager = new FeatureAppManager(mockRegistry);
 
         expect(() =>
-          manager.getAsyncFeatureAppDefinition('/example.js')
+          featureAppManager.getAsyncFeatureAppDefinition('/example.js')
         ).toThrowError(new Error('No module loader provided.'));
       });
     }
 
     describe('for a known Feature App module url', () => {
       it('returns the same async Feature App definition', () => {
-        const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(
+        const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
           '/example.js'
         );
 
-        expect(manager.getAsyncFeatureAppDefinition('/example.js')).toBe(
-          asyncFeatureAppDefinition
-        );
+        expect(
+          featureAppManager.getAsyncFeatureAppDefinition('/example.js')
+        ).toBe(asyncFeatureAppDefinition);
       });
     });
   });
@@ -148,11 +149,14 @@ describe('FeatureAppManager', () => {
       const mockConfig = {kind: 'test'};
       const idSpecifier = 'testIdSpecifier';
 
-      manager = new FeatureAppManager(mockRegistry, {
+      featureAppManager = new FeatureAppManager(mockRegistry, {
         configs: {[mockFeatureAppDefinition.id]: mockConfig}
       });
 
-      manager.getFeatureAppScope(mockFeatureAppDefinition, idSpecifier);
+      featureAppManager.getFeatureAppScope(
+        mockFeatureAppDefinition,
+        idSpecifier
+      );
 
       expect(mockRegistry.bindFeatureServices.mock.calls).toEqual([
         [mockFeatureAppDefinition, idSpecifier]
@@ -188,7 +192,10 @@ describe('FeatureAppManager', () => {
       });
 
       it("registers the Feature App's own Feature Services before binding its required Feature Services", () => {
-        manager.getFeatureAppScope(mockFeatureAppDefinition, 'testIdSpecifier');
+        featureAppManager.getFeatureAppScope(
+          mockFeatureAppDefinition,
+          'testIdSpecifier'
+        );
 
         expect(mockRegistry.registerFeatureServices.mock.calls).toEqual([
           [mockFeatureAppDefinition.ownFeatureServiceDefinitions, 'testId']
@@ -208,7 +215,7 @@ describe('FeatureAppManager', () => {
     describe('for a known Feature App definition', () => {
       describe('and no id specifier', () => {
         it('logs an info message after creation', () => {
-          manager.getFeatureAppScope(mockFeatureAppDefinition);
+          featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
 
           expect(spyConsoleInfo.mock.calls).toEqual([
             ['The Feature App "testId" has been successfully created.']
@@ -216,25 +223,25 @@ describe('FeatureAppManager', () => {
         });
 
         it('returns the same Feature App scope', () => {
-          const featureAppScope = manager.getFeatureAppScope(
+          const featureAppScope = featureAppManager.getFeatureAppScope(
             mockFeatureAppDefinition
           );
 
-          expect(manager.getFeatureAppScope(mockFeatureAppDefinition)).toBe(
-            featureAppScope
-          );
+          expect(
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition)
+          ).toBe(featureAppScope);
         });
 
         describe('when destroy() is called on the Feature App scope', () => {
           it('returns another Feature App scope', () => {
-            const featureAppScope = manager.getFeatureAppScope(
+            const featureAppScope = featureAppManager.getFeatureAppScope(
               mockFeatureAppDefinition
             );
 
             featureAppScope.destroy();
 
             expect(
-              manager.getFeatureAppScope(mockFeatureAppDefinition)
+              featureAppManager.getFeatureAppScope(mockFeatureAppDefinition)
             ).not.toBe(featureAppScope);
           });
         });
@@ -242,7 +249,7 @@ describe('FeatureAppManager', () => {
 
       describe('and an id specifier', () => {
         it('logs an info message after creation', () => {
-          manager.getFeatureAppScope(
+          featureAppManager.getFeatureAppScope(
             mockFeatureAppDefinition,
             'testIdSpecifier'
           );
@@ -255,13 +262,13 @@ describe('FeatureAppManager', () => {
         });
 
         it('returns the same Feature App scope', () => {
-          const featureAppScope = manager.getFeatureAppScope(
+          const featureAppScope = featureAppManager.getFeatureAppScope(
             mockFeatureAppDefinition,
             'testIdSpecifier'
           );
 
           expect(
-            manager.getFeatureAppScope(
+            featureAppManager.getFeatureAppScope(
               mockFeatureAppDefinition,
               'testIdSpecifier'
             )
@@ -270,7 +277,7 @@ describe('FeatureAppManager', () => {
 
         describe('when destroy() is called on the Feature App scope', () => {
           it('returns another Feature App scope', () => {
-            const featureAppScope = manager.getFeatureAppScope(
+            const featureAppScope = featureAppManager.getFeatureAppScope(
               mockFeatureAppDefinition,
               'testIdSpecifier'
             );
@@ -278,7 +285,7 @@ describe('FeatureAppManager', () => {
             featureAppScope.destroy();
 
             expect(
-              manager.getFeatureAppScope(
+              featureAppManager.getFeatureAppScope(
                 mockFeatureAppDefinition,
                 'testIdSpecifier'
               )
@@ -289,12 +296,12 @@ describe('FeatureAppManager', () => {
 
       describe('and a different id specifier', () => {
         it('returns another Feature App scope', () => {
-          const featureAppScope = manager.getFeatureAppScope(
+          const featureAppScope = featureAppManager.getFeatureAppScope(
             mockFeatureAppDefinition
           );
 
           expect(
-            manager.getFeatureAppScope(
+            featureAppManager.getFeatureAppScope(
               mockFeatureAppDefinition,
               'testIdSpecifier'
             )
@@ -305,7 +312,7 @@ describe('FeatureAppManager', () => {
 
     describe('#featureApp', () => {
       it("is the Feature App that the Feature App definition's create returns", () => {
-        const featureAppScope = manager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.getFeatureAppScope(
           mockFeatureAppDefinition
         );
 
@@ -315,7 +322,7 @@ describe('FeatureAppManager', () => {
 
     describe('#destroy', () => {
       it('unbinds the bound Feature Services', () => {
-        const featureAppScope = manager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.getFeatureAppScope(
           mockFeatureAppDefinition
         );
 
@@ -325,7 +332,7 @@ describe('FeatureAppManager', () => {
       });
 
       it('throws an error when destroy is called multiple times', () => {
-        const featureAppScope = manager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.getFeatureAppScope(
           mockFeatureAppDefinition,
           'testIdSpecifier'
         );
@@ -340,13 +347,16 @@ describe('FeatureAppManager', () => {
       });
 
       it('fails to destroy an already destroyed Feature App scope, even if this scope has been re-created', () => {
-        const featureAppScope = manager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.getFeatureAppScope(
           mockFeatureAppDefinition,
           'testIdSpecifier'
         );
 
         featureAppScope.destroy();
-        manager.getFeatureAppScope(mockFeatureAppDefinition, 'testIdSpecifier');
+        featureAppManager.getFeatureAppScope(
+          mockFeatureAppDefinition,
+          'testIdSpecifier'
+        );
 
         expect(() => featureAppScope.destroy()).toThrowError(
           new Error(
@@ -359,9 +369,9 @@ describe('FeatureAppManager', () => {
 
   describe('#destroy', () => {
     it('unbinds the bound Feature Services for all Feature Apps', () => {
-      manager.getFeatureAppScope(mockFeatureAppDefinition, 'test1');
-      manager.getFeatureAppScope(mockFeatureAppDefinition, 'test2');
-      manager.destroy();
+      featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, 'test1');
+      featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, 'test2');
+      featureAppManager.destroy();
 
       expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(2);
     });
@@ -369,15 +379,15 @@ describe('FeatureAppManager', () => {
 
   describe('#preloadFeatureApp', () => {
     beforeEach(() => {
-      manager = new FeatureAppManager(mockRegistry, {
+      featureAppManager = new FeatureAppManager(mockRegistry, {
         moduleLoader: mockModuleLoader
       });
     });
 
     it('preloads a Feature App definition so that the scope is synchronously available', async () => {
-      await manager.preloadFeatureApp('/example.js');
+      await featureAppManager.preloadFeatureApp('/example.js');
 
-      const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(
+      const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
         '/example.js'
       );
 
@@ -385,10 +395,10 @@ describe('FeatureAppManager', () => {
     });
 
     it('throws an error if no module loader was provided', () => {
-      manager = new FeatureAppManager(mockRegistry);
+      featureAppManager = new FeatureAppManager(mockRegistry);
 
       expect(() =>
-        manager.getAsyncFeatureAppDefinition('/example.js')
+        featureAppManager.getAsyncFeatureAppDefinition('/example.js')
       ).toThrowError(new Error('No module loader provided.'));
     });
   });

--- a/packages/demos/src/history-service/integrator.tsx
+++ b/packages/demos/src/history-service/integrator.tsx
@@ -8,9 +8,9 @@ import '../blueprint-css';
 import {historyConsumerDefinition} from './history-consumer-definition';
 import {rootLocationTransformer} from './root-location-transformer';
 
-const registry = new FeatureServiceRegistry();
+const featureServiceRegistry = new FeatureServiceRegistry();
 
-registry.registerFeatureServices(
+featureServiceRegistry.registerFeatureServices(
   [
     defineAsyncSsrManager(undefined),
     defineHistoryService(rootLocationTransformer)
@@ -18,17 +18,17 @@ registry.registerFeatureServices(
   'demo:integrator'
 );
 
-const manager = new FeatureAppManager(registry);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry);
 
 ReactDOM.render(
   <>
     <FeatureAppContainer
-      manager={manager}
+      featureAppManager={featureAppManager}
       featureAppDefinition={historyConsumerDefinition}
       idSpecifier="a"
     />
     <FeatureAppContainer
-      manager={manager}
+      featureAppManager={featureAppManager}
       featureAppDefinition={historyConsumerDefinition}
       idSpecifier="b"
     />

--- a/packages/demos/src/module-loader-amd/integrator.tsx
+++ b/packages/demos/src/module-loader-amd/integrator.tsx
@@ -5,12 +5,18 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import '../blueprint-css';
 
-const registry = new FeatureServiceRegistry();
-const manager = new FeatureAppManager(registry, {moduleLoader: loadAmdModule});
+const featureServiceRegistry = new FeatureServiceRegistry();
+
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule
+});
 
 defineExternals({react: React});
 
 ReactDOM.render(
-  <FeatureAppLoader manager={manager} src="feature-app.umd.js" />,
+  <FeatureAppLoader
+    featureAppManager={featureAppManager}
+    src="feature-app.umd.js"
+  />,
   document.querySelector('main')
 );

--- a/packages/demos/src/module-loader-commonjs/integrator.node.tsx
+++ b/packages/demos/src/module-loader-commonjs/integrator.node.tsx
@@ -6,15 +6,19 @@ import * as ReactDOM from 'react-dom/server';
 
 export default async function renderMainHtml(port: number): Promise<string> {
   const featureAppNodeUrl = `http://localhost:${port}/feature-app.commonjs.js`;
-  const registry = new FeatureServiceRegistry();
+  const featureServiceRegistry = new FeatureServiceRegistry();
 
-  const manager = new FeatureAppManager(registry, {
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
     moduleLoader: loadCommonJsModule
   });
 
-  await manager.preloadFeatureApp(featureAppNodeUrl);
+  await featureAppManager.preloadFeatureApp(featureAppNodeUrl);
 
   return ReactDOM.renderToString(
-    <FeatureAppLoader manager={manager} src="" serverSrc={featureAppNodeUrl} />
+    <FeatureAppLoader
+      featureAppManager={featureAppManager}
+      src=""
+      serverSrc={featureAppNodeUrl}
+    />
   );
 }

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 import {FeatureAppContainer} from '..';
 
 describe('FeatureAppContainer (on Node.js)', () => {
-  let mockManager: FeatureAppManagerLike;
+  let mockFeatureAppManager: FeatureAppManagerLike;
   let mockGetFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
@@ -25,7 +25,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
     mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
     mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
 
-    mockManager = {
+    mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: jest.fn(),
       getFeatureAppScope: mockGetFeatureAppScope,
       preloadFeatureApp: jest.fn(),
@@ -65,7 +65,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
         expect(() =>
           shallow(
             <FeatureAppContainer
-              manager={mockManager}
+              featureAppManager={mockFeatureAppManager}
               featureAppDefinition={mockFeatureAppDefinition}
             />
           )
@@ -91,7 +91,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
       expect(() =>
         shallow(
           <FeatureAppContainer
-            manager={mockManager}
+            featureAppManager={mockFeatureAppManager}
             featureAppDefinition={mockFeatureAppDefinition}
           />
         )

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -36,10 +36,10 @@ describe('FeatureAppContainer', () => {
     spyConsoleError.mockRestore();
   });
 
-  it('calls the manager with the given Feature App definition and id specifier', () => {
+  it('calls the feature app manager with the given Feature App definition and id specifier', () => {
     shallow(
       <FeatureAppContainer
-        manager={mockManager}
+        featureAppManager={mockManager}
         featureAppDefinition={mockFeatureAppDefinition}
         idSpecifier="testIdSpecifier"
       />
@@ -63,7 +63,7 @@ describe('FeatureAppContainer', () => {
     it('renders the React element', () => {
       const wrapper = shallow(
         <FeatureAppContainer
-          manager={mockManager}
+          featureAppManager={mockManager}
           featureAppDefinition={mockFeatureAppDefinition}
         />
       );
@@ -79,7 +79,7 @@ describe('FeatureAppContainer', () => {
       it('calls destroy() on the Feature App scope', () => {
         const wrapper = shallow(
           <FeatureAppContainer
-            manager={mockManager}
+            featureAppManager={mockManager}
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -105,7 +105,7 @@ describe('FeatureAppContainer', () => {
         it('logs the error', () => {
           const wrapper = shallow(
             <FeatureAppContainer
-              manager={mockManager}
+              featureAppManager={mockManager}
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -133,7 +133,7 @@ describe('FeatureAppContainer', () => {
     it("renders a container and passes it to the Feature App's render method", () => {
       const wrapper = mount(
         <FeatureAppContainer
-          manager={mockManager}
+          featureAppManager={mockManager}
           featureAppDefinition={mockFeatureAppDefinition}
         />
       );
@@ -147,7 +147,7 @@ describe('FeatureAppContainer', () => {
       it('calls destroy() on the Feature App scope', () => {
         const wrapper = shallow(
           <FeatureAppContainer
-            manager={mockManager}
+            featureAppManager={mockManager}
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -173,7 +173,7 @@ describe('FeatureAppContainer', () => {
         it('logs the error', () => {
           const wrapper = shallow(
             <FeatureAppContainer
-              manager={mockManager}
+              featureAppManager={mockManager}
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -206,7 +206,7 @@ describe('FeatureAppContainer', () => {
       it('renders nothing and logs an error', () => {
         const wrapper = shallow(
           <FeatureAppContainer
-            manager={mockManager}
+            featureAppManager={mockManager}
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -236,7 +236,7 @@ describe('FeatureAppContainer', () => {
     it('renders nothing and logs an error', () => {
       const wrapper = shallow(
         <FeatureAppContainer
-          manager={mockManager}
+          featureAppManager={mockManager}
           featureAppDefinition={mockFeatureAppDefinition}
         />
       );
@@ -250,7 +250,7 @@ describe('FeatureAppContainer', () => {
       it('does nothing', () => {
         const wrapper = shallow(
           <FeatureAppContainer
-            manager={mockManager}
+            featureAppManager={mockManager}
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 import {FeatureAppLoader} from '..';
 
 describe('FeatureAppLoader (on Node.js)', () => {
-  let mockManager: FeatureAppManagerLike;
+  let mockFeatureAppManager: FeatureAppManagerLike;
   let mockGetAsyncFeatureAppDefinition: jest.Mock;
   let mockAsyncFeatureAppDefinition: AsyncValue<FeatureAppDefinition<unknown>>;
   let spyConsoleError: jest.SpyInstance;
@@ -28,7 +28,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       () => mockAsyncFeatureAppDefinition
     );
 
-    mockManager = {
+    mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
       getFeatureAppScope: jest.fn(),
       preloadFeatureApp: jest.fn(),
@@ -45,9 +45,15 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
   describe('without a serverSrc', () => {
     it('does not try to load a Feature App definition', () => {
-      shallow(<FeatureAppLoader manager={mockManager} src="example.js" />, {
-        disableLifecycleMethods: true
-      });
+      shallow(
+        <FeatureAppLoader
+          featureAppManager={mockFeatureAppManager}
+          src="example.js"
+        />,
+        {
+          disableLifecycleMethods: true
+        }
+      );
 
       expect(mockGetAsyncFeatureAppDefinition).not.toHaveBeenCalled();
     });
@@ -57,7 +63,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
     it('loads a Feature App definition for the serverSrc', () => {
       shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="example.js"
           serverSrc="example-node.js"
         />,
@@ -83,7 +89,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
         expect(() =>
           shallow(
             <FeatureAppLoader
-              manager={mockManager}
+              featureAppManager={mockFeatureAppManager}
               src="example.js"
               serverSrc="example-node.js"
               idSpecifier="testIdSpecifier"

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 import {FeatureAppContainer, FeatureAppLoader} from '..';
 
 describe('FeatureAppLoader', () => {
-  let mockManager: FeatureAppManagerLike;
+  let mockFeatureAppManager: FeatureAppManagerLike;
   let mockGetAsyncFeatureAppDefinition: jest.Mock;
   let mockAsyncFeatureAppDefinition: AsyncValue<FeatureAppDefinition<unknown>>;
   let spyConsoleError: jest.SpyInstance;
@@ -28,7 +28,7 @@ describe('FeatureAppLoader', () => {
       () => mockAsyncFeatureAppDefinition
     );
 
-    mockManager = {
+    mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
       getFeatureAppScope: jest.fn(),
       preloadFeatureApp: jest.fn(),
@@ -45,13 +45,18 @@ describe('FeatureAppLoader', () => {
 
   it('throws an error if no src is provided', () => {
     expect(() =>
-      shallow(<FeatureAppLoader manager={mockManager} src="" />)
+      shallow(
+        <FeatureAppLoader featureAppManager={mockFeatureAppManager} src="" />
+      )
     ).toThrowError(new Error('No src provided.'));
   });
 
   it('initially renders nothing', () => {
     const wrapper = shallow(
-      <FeatureAppLoader manager={mockManager} src="/test.js" />
+      <FeatureAppLoader
+        featureAppManager={mockFeatureAppManager}
+        src="/test.js"
+      />
     );
 
     expect(wrapper.isEmptyRender()).toBe(true);
@@ -59,7 +64,12 @@ describe('FeatureAppLoader', () => {
 
   describe('without a css prop', () => {
     it('does not change the document head', () => {
-      shallow(<FeatureAppLoader manager={mockManager} src="/test.js" />);
+      shallow(
+        <FeatureAppLoader
+          featureAppManager={mockFeatureAppManager}
+          src="/test.js"
+        />
+      );
 
       expect(document.head).toMatchSnapshot();
     });
@@ -69,7 +79,7 @@ describe('FeatureAppLoader', () => {
     it('appends link elements to the document head', () => {
       shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="/test.js"
           css={[{href: 'foo.css'}, {href: 'bar.css', media: 'print'}]}
         />
@@ -82,7 +92,7 @@ describe('FeatureAppLoader', () => {
       it('does not append the css a second time', () => {
         shallow(
           <FeatureAppLoader
-            manager={mockManager}
+            featureAppManager={mockFeatureAppManager}
             src="/test.js"
             css={[{href: 'foo.css'}]}
           />
@@ -90,7 +100,7 @@ describe('FeatureAppLoader', () => {
 
         shallow(
           <FeatureAppLoader
-            manager={mockManager}
+            featureAppManager={mockFeatureAppManager}
             src="/test.js"
             css={[{href: 'foo.css'}]}
           />
@@ -118,7 +128,7 @@ describe('FeatureAppLoader', () => {
     it('renders a FeatureAppContainer', () => {
       const wrapper = shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="/test.js"
           idSpecifier="testIdSpecifier"
         />
@@ -126,7 +136,7 @@ describe('FeatureAppLoader', () => {
 
       expect(wrapper.getElement()).toEqual(
         <FeatureAppContainer
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           featureAppDefinition={mockFeatureAppDefinition}
           idSpecifier="testIdSpecifier"
         />
@@ -150,7 +160,7 @@ describe('FeatureAppLoader', () => {
     it('renders nothing and logs an error', () => {
       const wrapper = shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="/test.js"
           idSpecifier="testIdSpecifier"
         />
@@ -186,7 +196,10 @@ describe('FeatureAppLoader', () => {
 
     it('initially renders nothing', () => {
       const wrapper = shallow(
-        <FeatureAppLoader manager={mockManager} src="/test.js" />
+        <FeatureAppLoader
+          featureAppManager={mockFeatureAppManager}
+          src="/test.js"
+        />
       );
 
       expect(wrapper.isEmptyRender()).toBe(true);
@@ -195,7 +208,7 @@ describe('FeatureAppLoader', () => {
     it('renders a FeatureAppContainer when loaded', async () => {
       const wrapper = shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="/test.js"
           idSpecifier="testIdSpecifier"
         />
@@ -205,7 +218,7 @@ describe('FeatureAppLoader', () => {
 
       expect(wrapper.getElement()).toEqual(
         <FeatureAppContainer
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           featureAppDefinition={mockFeatureAppDefinition}
           idSpecifier="testIdSpecifier"
         />
@@ -215,7 +228,10 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('renders nothing', async () => {
         const wrapper = shallow(
-          <FeatureAppLoader manager={mockManager} src="/test.js" />
+          <FeatureAppLoader
+            featureAppManager={mockFeatureAppManager}
+            src="/test.js"
+          />
         );
 
         wrapper.unmount();
@@ -244,7 +260,7 @@ describe('FeatureAppLoader', () => {
     it('renders nothing and logs an error', async () => {
       const wrapper = shallow(
         <FeatureAppLoader
-          manager={mockManager}
+          featureAppManager={mockFeatureAppManager}
           src="/test.js"
           idSpecifier="testIdSpecifier"
         />
@@ -271,7 +287,10 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('logs an error', async () => {
         const wrapper = shallow(
-          <FeatureAppLoader manager={mockManager} src="/test.js" />
+          <FeatureAppLoader
+            featureAppManager={mockFeatureAppManager}
+            src="/test.js"
+          />
         );
 
         wrapper.unmount();

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -17,7 +17,7 @@ export interface ReactFeatureApp {
 export type FeatureApp = DomFeatureApp | ReactFeatureApp;
 
 export interface FeatureAppContainerProps {
-  readonly manager: FeatureAppManagerLike;
+  readonly featureAppManager: FeatureAppManagerLike;
   readonly featureAppDefinition: FeatureAppDefinition<unknown>;
   readonly idSpecifier?: string;
 }
@@ -37,10 +37,10 @@ export class FeatureAppContainer extends React.PureComponent<
   public constructor(props: FeatureAppContainerProps) {
     super(props);
 
-    const {manager, featureAppDefinition, idSpecifier} = props;
+    const {featureAppManager, featureAppDefinition, idSpecifier} = props;
 
     try {
-      this.featureAppScope = manager.getFeatureAppScope(
+      this.featureAppScope = featureAppManager.getFeatureAppScope(
         featureAppDefinition,
         idSpecifier
       );

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -8,7 +8,7 @@ export interface Css {
 }
 
 export interface FeatureAppLoaderProps {
-  readonly manager: FeatureAppManagerLike;
+  readonly featureAppManager: FeatureAppManagerLike;
   readonly src: string;
   readonly serverSrc?: string;
   readonly css?: Css[];
@@ -37,7 +37,7 @@ export class FeatureAppLoader extends React.PureComponent<
   public constructor(props: FeatureAppLoaderProps) {
     super(props);
 
-    const {manager, src: browserSrc, serverSrc} = props;
+    const {featureAppManager, src: browserSrc, serverSrc} = props;
     const src = inBrowser ? browserSrc : serverSrc;
 
     if (!src) {
@@ -48,7 +48,9 @@ export class FeatureAppLoader extends React.PureComponent<
       return;
     }
 
-    const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(src);
+    const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
+      src
+    );
 
     if (asyncFeatureAppDefinition.error) {
       this.reportError(asyncFeatureAppDefinition.error);
@@ -73,8 +75,11 @@ export class FeatureAppLoader extends React.PureComponent<
       return;
     }
 
-    const {manager, src} = this.props;
-    const asyncFeatureAppDefinition = manager.getAsyncFeatureAppDefinition(src);
+    const {featureAppManager, src} = this.props;
+
+    const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
+      src
+    );
 
     try {
       const featureAppDefinition = await asyncFeatureAppDefinition.promise;
@@ -97,7 +102,7 @@ export class FeatureAppLoader extends React.PureComponent<
 
   public render(): React.ReactNode {
     const {featureAppDefinition, hasError} = this.state;
-    const {manager, idSpecifier} = this.props;
+    const {featureAppManager, idSpecifier} = this.props;
 
     if (hasError) {
       // An error UI could be rendered here.
@@ -111,7 +116,7 @@ export class FeatureAppLoader extends React.PureComponent<
 
     return (
       <FeatureAppContainer
-        manager={manager}
+        featureAppManager={featureAppManager}
         featureAppDefinition={featureAppDefinition}
         idSpecifier={idSpecifier}
       />


### PR DESCRIPTION
This is in preparation for the task " Integrate Async SSR Manager into FeatureAppLoader" of #25, where the new prop `asyncSsrManager` will be added to the `FeatureAppLoader`.