### PR TITLE
feat(async-ssr-manager): add rerender method

### DIFF
--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -87,18 +87,51 @@ describe('asyncSsrManagerDefinition', () => {
         });
       });
 
-      describe('with an integrator, and a consumer that triggers a rerender', () => {
+      describe('with an integrator, and a consumer that triggers a rerender (using the rerenderAfter method with a promise)', () => {
         it('resolves with an html string after the second render pass', async () => {
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
             'test:integrator'
           ).featureService;
 
-          const asyncSsrManagerConsumer = createAsyncSsrManagerConsumer(
-            'test:consumer'
-          );
+          const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
+            .featureService;
+
+          let firstRender = true;
 
           const mockRender = jest.fn(() => {
-            asyncSsrManagerConsumer.render();
+            if (firstRender) {
+              firstRender = false;
+              asyncSsrManagerConsumer.rerenderAfter(Promise.resolve());
+            }
+
+            return 'testHtml';
+          });
+
+          const html = await asyncSsrManagerIntegrator.renderUntilCompleted(
+            mockRender
+          );
+
+          expect(html).toEqual('testHtml');
+          expect(mockRender).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe('with an integrator, and a consumer that triggers a rerender (using the rerender method)', () => {
+        it('resolves with an html string after the second render pass', async () => {
+          const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
+            'test:integrator'
+          ).featureService;
+
+          const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
+            .featureService;
+
+          let firstRender = true;
+
+          const mockRender = jest.fn(() => {
+            if (firstRender) {
+              firstRender = false;
+              asyncSsrManagerConsumer.rerender();
+            }
 
             return 'testHtml';
           });

--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -12,6 +12,7 @@ export interface AsyncSsrManagerConfig {
 
 export interface AsyncSsrManagerV0 {
   renderUntilCompleted(render: () => string): Promise<string>;
+  rerender(): void;
   rerenderAfter(promise: Promise<unknown>): void;
 }
 

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -26,6 +26,10 @@ export class AsyncSsrManager implements AsyncSsrManagerV0 {
     return Promise.race([renderPromise, renderingTimeout(this.timeout)]);
   }
 
+  public rerender(): void {
+    this.rerenderAfter(Promise.resolve());
+  }
+
   public rerenderAfter(promise: Promise<unknown>): void {
     this.rerenderPromises.add(promise);
   }

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -42,6 +42,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
     };
 
     mockAsyncSsrManager = {
+      rerender: jest.fn(),
       rerenderAfter: jest.fn(),
       renderUntilCompleted: jest.fn()
     };

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -42,6 +42,7 @@ describe('FeatureAppLoader', () => {
     };
 
     mockAsyncSsrManager = {
+      rerender: jest.fn(),
       rerenderAfter: jest.fn(),
       renderUntilCompleted: jest.fn()
     };


### PR DESCRIPTION
Use case: When Feature Services want to trigger a rerender after their state has been changed, it would be a bit awkward to force them to pass `Promise.resolve()` into `rerenderAfter`.