### PR TITLE
build(demos): resolve tsconfig paths when watching demos

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "verify:size-limit": "lerna exec --no-private --ignore @feature-hub/module-loader-commonjs --parallel -- size-limit",
     "preverify:sort-package-jsons": "yarn sort-package-jsons",
     "verify:sort-package-jsons": "git diff --exit-code package.json packages/*/package.json",
-    "watch:demo": "lerna exec --scope @feature-hub/demos -- ts-node src/watch-demo.ts",
+    "watch:demo": "lerna exec --scope @feature-hub/demos -- ts-node -r tsconfig-paths/register src/watch-demo.ts",
     "watch:test": "yarn test --watch --no-coverage --no-verbose",
     "watch:website": "lerna exec --scope @feature-hub/website -- docusaurus-start"
   },

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -27,6 +27,7 @@
     "style-loader": "^0.23.1",
     "ts-loader": "^5.3.1",
     "ts-node": "^7.0.1",
+    "tsconfig-paths": "^3.7.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "url-loader": "^1.1.2",
     "webpack": "^4.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12615,7 +12615,7 @@ tsconfig-paths-webpack-plugin@^3.2.0:
     enhanced-resolve "^4.0.0"
     tsconfig-paths "^3.4.0"
 
-tsconfig-paths@^3.4.0:
+tsconfig-paths@^3.4.0, tsconfig-paths@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.7.0.tgz#02ae978db447b22e09dafcd4198be95c4885ceb2"
   integrity sha512-7iE+Q/2E1lgvxD+c0Ot+GFFmgmfIjt/zCayyruXkXQ84BLT85gHXy0WSoQSiuFX9+d+keE/jiON7notV74ZY+A==


### PR DESCRIPTION
Otherwise built `lib` directories are required to watch a demo.