### PR TITLE
feat(core): move Feature Service dependencies into a separate key

### DIFF
--- a/packages/core/src/__tests__/feature-service-registry.test.ts
+++ b/packages/core/src/__tests__/feature-service-registry.test.ts
@@ -56,7 +56,7 @@ describe('FeatureServiceRegistry', () => {
 
     providerDefinitionB = {
       id: 'b',
-      optionalDependencies: {a: '^1.0'},
+      optionalDependencies: {featureServices: {a: '^1.0'}},
       create: jest.fn(() => ({'1.0': binderB}))
     };
 
@@ -66,7 +66,7 @@ describe('FeatureServiceRegistry', () => {
 
     providerDefinitionC = {
       id: 'c',
-      dependencies: {a: '^1.0', b: '1.0'},
+      dependencies: {featureServices: {a: '^1.0', b: '1.0'}},
       create: jest.fn(() => ({'2.0': binderC}))
     };
 
@@ -202,7 +202,7 @@ describe('FeatureServiceRegistry', () => {
     it('doesnt fail to register the Feature Service "b" due to the lack of optional dependency "a"', () => {
       providerDefinitionB = {
         id: 'b',
-        optionalDependencies: {a: '^1.0'},
+        optionalDependencies: {featureServices: {a: '^1.0'}},
         create: jest.fn(() => ({'1.0': jest.fn()}))
       };
 
@@ -226,7 +226,7 @@ describe('FeatureServiceRegistry', () => {
     it('fails to register the Feature Service "d" due to an unsupported dependency version', () => {
       const stateProviderD = {
         id: 'd',
-        dependencies: {a: '1.0'},
+        dependencies: {featureServices: {a: '1.0'}},
         create: jest.fn()
       };
 
@@ -245,7 +245,7 @@ describe('FeatureServiceRegistry', () => {
     it('does not fail to register the Feature Service "d" due to an unsupported optional dependency version', () => {
       const stateProviderD = {
         id: 'd',
-        optionalDependencies: {a: '1.0'},
+        optionalDependencies: {featureServices: {a: '1.0'}},
         create: jest.fn(() => ({}))
       };
 
@@ -272,7 +272,7 @@ describe('FeatureServiceRegistry', () => {
     it('fails to register the Feature Service "d" due to an invalid dependency version', () => {
       const stateProviderDefinitionD = {
         id: 'd',
-        dependencies: {a: ''},
+        dependencies: {featureServices: {a: ''}},
         create: jest.fn()
       };
 
@@ -291,7 +291,7 @@ describe('FeatureServiceRegistry', () => {
     it('does not fail to register the Feature Service "d" due to an invalid optional dependency version', () => {
       const stateProviderDefinitionD = {
         id: 'd',
-        optionalDependencies: {a: ''},
+        optionalDependencies: {featureServices: {a: ''}},
         create: jest.fn(() => ({}))
       };
 
@@ -318,13 +318,13 @@ describe('FeatureServiceRegistry', () => {
     it('fails to register the Feature Service "e" due to a dependency with an invalid version', () => {
       const stateProviderDefinitionD = {
         id: 'd',
-        dependencies: {},
+        dependencies: {featureServices: {}},
         create: () => ({foo: jest.fn()})
       };
 
       const stateProviderDefinitionE = {
         id: 'e',
-        dependencies: {d: '1.0'},
+        dependencies: {featureServices: {d: '1.0'}},
         create: jest.fn()
       };
 
@@ -366,7 +366,7 @@ describe('FeatureServiceRegistry', () => {
 
         expect(
           featureServiceRegistry.bindFeatureServices(
-            {id: 'foo', dependencies: {a: '1.1'}},
+            {id: 'foo', dependencies: {featureServices: {a: '1.1'}}},
             'bar'
           )
         ).toEqual({
@@ -392,7 +392,7 @@ describe('FeatureServiceRegistry', () => {
         expect(
           featureServiceRegistry.bindFeatureServices({
             id: 'foo',
-            dependencies: {a: '1.1'}
+            dependencies: {featureServices: {a: '1.1'}}
           })
         ).toEqual({
           featureServices: {a: featureServiceA},
@@ -418,7 +418,7 @@ describe('FeatureServiceRegistry', () => {
           expect(
             featureServiceRegistry.bindFeatureServices({
               id: 'foo',
-              optionalDependencies: {b: '1.0', a: '1.1'}
+              optionalDependencies: {featureServices: {b: '1.0', a: '1.1'}}
             })
           ).toEqual({
             featureServices: {a: featureServiceA},
@@ -443,7 +443,7 @@ describe('FeatureServiceRegistry', () => {
           expect(
             featureServiceRegistry.bindFeatureServices({
               id: 'foo',
-              optionalDependencies: {a: '1.1', b: '1.0'}
+              optionalDependencies: {featureServices: {a: '1.1', b: '1.0'}}
             })
           ).toEqual({
             featureServices: {a: featureServiceA},
@@ -468,7 +468,7 @@ describe('FeatureServiceRegistry', () => {
           expect(
             featureServiceRegistry.bindFeatureServices({
               id: 'foo',
-              optionalDependencies: {a: '1.1', b: '^1.0'}
+              optionalDependencies: {featureServices: {a: '1.1', b: '^1.0'}}
             })
           ).toEqual({
             featureServices: {a: featureServiceA, b: featureServiceB},
@@ -526,7 +526,7 @@ describe('FeatureServiceRegistry', () => {
 
         const bindings = featureServiceRegistry.bindFeatureServices({
           id: 'foo',
-          dependencies: {a: '1.1', b: '1.0', c: '2.0'}
+          dependencies: {featureServices: {a: '1.1', b: '1.0', c: '2.0'}}
         });
 
         bindings.unbind();

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -141,6 +141,17 @@ function createDependencyGraph(
   return dependencyGraph;
 }
 
+function isOptionalFeatureServiceDependency(
+  definition: FeatureServiceConsumerDefinition,
+  providerId: ProviderId
+): boolean {
+  return Boolean(
+    definition.optionalDependencies &&
+      definition.optionalDependencies.featureServices &&
+      definition.optionalDependencies.featureServices[providerId]
+  );
+}
+
 function createProviderDefinitionById(
   definitions: FeatureServiceProviderDefinition<SharedFeatureService>[]
 ): ProviderDefinitionsById {
@@ -251,12 +262,7 @@ export class FeatureServiceRegistry implements FeatureServiceRegistryLike {
     consumerDefinition: FeatureServiceConsumerDefinition,
     consumerIdSpecifier?: string
   ): FeatureServicesBinding {
-    const {
-      id: consumerId,
-      dependencies = {
-        featureServices: {}
-      }
-    } = consumerDefinition;
+    const {id: consumerId} = consumerDefinition;
 
     const consumerUid = createUid(consumerId, consumerIdSpecifier);
 
@@ -273,7 +279,12 @@ export class FeatureServiceRegistry implements FeatureServiceRegistryLike {
         providerId,
         consumerUid,
         allDependencies[providerId],
-        {optional: !dependencies.featureServices.hasOwnProperty(providerId)}
+        {
+          optional: isOptionalFeatureServiceDependency(
+            consumerDefinition,
+            providerId
+          )
+        }
       );
 
       if (!binding) {

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -152,7 +152,7 @@ function isOptionalFeatureServiceDependency(
   );
 }
 
-function createProviderDefinitionById(
+function createProviderDefinitionsById(
   definitions: FeatureServiceProviderDefinition<SharedFeatureService>[]
 ): ProviderDefinitionsById {
   const providerDefinitionsById: ProviderDefinitionsById = new Map();
@@ -204,7 +204,7 @@ export class FeatureServiceRegistry implements FeatureServiceRegistryLike {
     >[],
     consumerId: string
   ): void {
-    const providerDefinitionsById = createProviderDefinitionById(
+    const providerDefinitionsById = createProviderDefinitionsById(
       providerDefinitions
     );
 

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -22,14 +22,14 @@ export interface FeatureServiceConsumerDefinition {
      * A map of required Feature Services with their ID as key and a
      * semver-compatible version string as value.
      */
-    featureServices: FeatureServiceConsumerDependencies;
+    readonly featureServices: FeatureServiceConsumerDependencies;
   };
   readonly optionalDependencies?: {
     /**
      * A map of optional Feature Services with their ID as key and a
      * semver-compatible version string as value.
      */
-    featureServices: FeatureServiceConsumerDependencies;
+    readonly featureServices: FeatureServiceConsumerDependencies;
   };
 }
 

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -275,16 +275,16 @@ export class FeatureServiceRegistry implements FeatureServiceRegistryLike {
     const allDependencies = mergeFeatureServiceDependencies(consumerDefinition);
 
     for (const providerId of Object.keys(allDependencies)) {
+      const optional = isOptionalFeatureServiceDependency(
+        consumerDefinition,
+        providerId
+      );
+
       const binding = this.bindFeatureService(
         providerId,
         consumerUid,
         allDependencies[providerId],
-        {
-          optional: isOptionalFeatureServiceDependency(
-            consumerDefinition,
-            providerId
-          )
-        }
+        {optional}
       );
 
       if (!binding) {

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -142,13 +142,13 @@ function createDependencyGraph(
 }
 
 function isOptionalFeatureServiceDependency(
-  definition: FeatureServiceConsumerDefinition,
+  {optionalDependencies}: FeatureServiceConsumerDefinition,
   providerId: ProviderId
 ): boolean {
   return Boolean(
-    definition.optionalDependencies &&
-      definition.optionalDependencies.featureServices &&
-      definition.optionalDependencies.featureServices[providerId]
+    optionalDependencies &&
+      optionalDependencies.featureServices &&
+      optionalDependencies.featureServices.hasOwnProperty(providerId)
   );
 }
 

--- a/packages/demos/src/history-service/history-consumer-definition.tsx
+++ b/packages/demos/src/history-service/history-consumer-definition.tsx
@@ -14,7 +14,9 @@ export const historyConsumerDefinition: FeatureAppDefinition<
   id: 'test:history-consumer',
 
   dependencies: {
-    's2:history': '^0.1'
+    featureServices: {
+      's2:history': '^0.1'
+    }
   },
 
   create: ({featureServices, idSpecifier}) => {

--- a/packages/demos/src/server-side-rendering/feature-app.tsx
+++ b/packages/demos/src/server-side-rendering/feature-app.tsx
@@ -22,11 +22,15 @@ const featureAppDefinition: FeatureAppDefinition<
   id: 'test:hello-world',
 
   dependencies: {
-    's2:serialized-state-manager': '^0.1'
+    featureServices: {
+      's2:serialized-state-manager': '^0.1'
+    }
   },
 
   optionalDependencies: {
-    's2:async-ssr-manager': '^0.1'
+    featureServices: {
+      's2:async-ssr-manager': '^0.1'
+    }
   },
 
   create: env => {

--- a/packages/demos/src/server-side-rendering/integrator.node.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.node.tsx
@@ -19,8 +19,10 @@ export default async function renderApp({
   const integratorDefinition = {
     id: 'test:integrator',
     dependencies: {
-      [asyncSsrManagerDefinition.id]: '^0.1',
-      [serializedStateManagerDefinition.id]: '^0.1'
+      featureServices: {
+        [asyncSsrManagerDefinition.id]: '^0.1',
+        [serializedStateManagerDefinition.id]: '^0.1'
+      }
     }
   };
 

--- a/packages/demos/src/server-side-rendering/integrator.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.tsx
@@ -23,7 +23,9 @@ function getSerializedStatesFromDom(): string | undefined {
   const integratorDefinition = {
     id: 'test:integrator',
     dependencies: {
-      [serializedStateManagerDefinition.id]: '^0.1'
+      featureServices: {
+        [serializedStateManagerDefinition.id]: '^0.1'
+      }
     }
   };
 

--- a/packages/history-service/src/__tests__/define-history-service.test.ts
+++ b/packages/history-service/src/__tests__/define-history-service.test.ts
@@ -41,7 +41,7 @@ describe('defineHistoryService', () => {
     expect(historyServiceDefinition.dependencies).toBeUndefined();
 
     expect(historyServiceDefinition.optionalDependencies).toEqual({
-      's2:server-request': '^0.1'
+      featureServices: {'s2:server-request': '^0.1'}
     });
   });
 

--- a/packages/history-service/src/define-history-service.ts
+++ b/packages/history-service/src/define-history-service.ts
@@ -33,7 +33,9 @@ export function defineHistoryService(
 > {
   return {
     id: 's2:history',
-    optionalDependencies: {'s2:server-request': '^0.1'},
+    optionalDependencies: {
+      featureServices: {'s2:server-request': '^0.1'}
+    },
 
     create: env => {
       const serverRequest = env.featureServices['s2:server-request'];


### PR DESCRIPTION
To allow for `dependencies`/`optionalDependencies` other then Feature Services, namely externals, introduce a `featureServices` key in `dependencies` and `optionalDependencies` of a `FeatureServiceConsumerDefinition` that contains the Feature Service dependency map.