### PR TITLE
feat(demos): use a FeatureAppLoader in "Feature App in Feature App" demo

### DIFF
--- a/packages/demos/src/feature-app-in-feature-app/integrator.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.tsx
@@ -1,20 +1,26 @@
 import {FeatureAppManager, FeatureServiceRegistry} from '@feature-hub/core';
-import {
-  FeatureAppContainer,
-  FeatureHubContextProvider
-} from '@feature-hub/react';
+import {defineExternals, loadAmdModule} from '@feature-hub/module-loader-amd';
+import * as FeatureHubReact from '@feature-hub/react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import '../blueprint-css';
-import featureAppDefinition from './feature-app-outer';
 
 const featureServiceRegistry = new FeatureServiceRegistry();
 
-const featureAppManager = new FeatureAppManager(featureServiceRegistry);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule
+});
+
+defineExternals({
+  react: React,
+  '@feature-hub/react': FeatureHubReact
+});
+
+const {FeatureHubContextProvider, FeatureAppLoader} = FeatureHubReact;
 
 ReactDOM.render(
   <FeatureHubContextProvider value={{featureAppManager}}>
-    <FeatureAppContainer featureAppDefinition={featureAppDefinition} />
+    <FeatureAppLoader src="feature-app.umd.js" />
   </FeatureHubContextProvider>,
 
   document.querySelector('main')

--- a/packages/demos/src/feature-app-in-feature-app/webpack-config.ts
+++ b/packages/demos/src/feature-app-in-feature-app/webpack-config.ts
@@ -5,6 +5,19 @@ import {webpackBaseConfig} from '../webpack-base-config';
 export default [
   {
     ...webpackBaseConfig,
+    entry: join(__dirname, './feature-app-outer.tsx'),
+    externals: {
+      react: 'react',
+      '@feature-hub/react': '@feature-hub/react'
+    },
+    output: {
+      filename: 'feature-app.umd.js',
+      libraryTarget: 'umd',
+      publicPath: '/'
+    }
+  },
+  {
+    ...webpackBaseConfig,
     entry: join(__dirname, './integrator.tsx'),
     output: {
       filename: 'integrator.js',


### PR DESCRIPTION
This shows that `@feature-hub/react` must be defined as an external dependency when a Feature App wants to render another Feature App.