### PR TITLE
docs(website): use Prism for syntax highlighting

### DIFF
--- a/packages/website/siteConfig.js
+++ b/packages/website/siteConfig.js
@@ -13,6 +13,7 @@ const siteConfig = {
   ],
   colors: {primaryColor: '#500dc5', secondaryColor: '#ea3458'},
   copyright: `Copyright (c) 2018-${new Date().getFullYear()} SinnerSchrader Deutschland GmbH`,
+  usePrism: ['js', 'jsx'],
   highlight: {theme: 'default'},
   onPageNav: 'separate',
   cleanUrl: true,


### PR DESCRIPTION
## Before (default)

<img width="816" alt="screen shot 2019-02-01 at 11 15 16" src="https://user-images.githubusercontent.com/761683/52116959-cfdaca80-2612-11e9-8510-db732a472371.png">

## After (with Prism)

<img width="809" alt="screen shot 2019-02-01 at 11 14 50" src="https://user-images.githubusercontent.com/761683/52116981-dd905000-2612-11e9-96f0-7ebbe3c7a9c6.png">
