### PR TITLE
feat(core): remove FeatureAppManager#destroy

### DIFF
--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -485,16 +485,6 @@ describe('FeatureAppManager', () => {
     });
   });
 
-  describe('#destroy', () => {
-    it('unbinds the bound Feature Services for all Feature Apps', () => {
-      featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, 'test1');
-      featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, 'test2');
-      featureAppManager.destroy();
-
-      expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe('#preloadFeatureApp', () => {
     beforeEach(() => {
       featureAppManager = new FeatureAppManager(

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -67,7 +67,6 @@ export interface FeatureAppManagerLike {
   ): FeatureAppScope<TFeatureApp>;
 
   preloadFeatureApp(url: string): Promise<void>;
-  destroy(): void;
 }
 
 export interface FeatureAppManagerOptions {
@@ -142,12 +141,6 @@ export class FeatureAppManager implements FeatureAppManagerLike {
 
   public async preloadFeatureApp(url: string): Promise<void> {
     await this.getAsyncFeatureAppDefinition(url).promise;
-  }
-
-  public destroy(): void {
-    for (const featureAppScope of this.featureAppScopes.values()) {
-      featureAppScope.destroy();
-    }
   }
 
   private createAsyncFeatureAppDefinition(

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -29,8 +29,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
     mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: jest.fn(),
       getFeatureAppScope: mockGetFeatureAppScope,
-      preloadFeatureApp: jest.fn(),
-      destroy: jest.fn()
+      preloadFeatureApp: jest.fn()
     };
 
     stubbedConsole = stubMethods(console);

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -25,8 +25,7 @@ describe('FeatureAppContainer', () => {
     mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: jest.fn(),
       getFeatureAppScope: mockGetFeatureAppScope,
-      preloadFeatureApp: jest.fn(),
-      destroy: jest.fn()
+      preloadFeatureApp: jest.fn()
     };
 
     stubbedConsole = stubMethods(console);

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -43,8 +43,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
     mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
       getFeatureAppScope: jest.fn(),
-      preloadFeatureApp: jest.fn(),
-      destroy: jest.fn()
+      preloadFeatureApp: jest.fn()
     };
 
     mockAsyncSsrManager = {

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -44,8 +44,7 @@ describe('FeatureAppLoader', () => {
     mockFeatureAppManager = {
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
       getFeatureAppScope: jest.fn(),
-      preloadFeatureApp: jest.fn(),
-      destroy: jest.fn()
+      preloadFeatureApp: jest.fn()
     };
 
     mockAsyncSsrManager = {


### PR DESCRIPTION
Since the `FeatureServiceRegistry` doesn't have a destroy method all actors in a Feature Hub environment have to make sure to that they don't allocate non-garbage-collectable resources that outlive a request while server-side-rendering anyway. We deemed this to be an acceptable requirement. Therefore remove the `destroy` method from the `FeatureAppManager`.