### PR TITLE
feat(core): make ExternalsValidator optional for the FeatureAppManager

### DIFF
--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -175,6 +175,27 @@ describe('FeatureAppManager', () => {
       ]);
     });
 
+    describe('without an ExternalsValidator provided to the FeatureAppManager', () => {
+      describe('with a Feature App definition that is declaring external dependencies', () => {
+        beforeEach(() => {
+          mockFeatureAppDefinition = {
+            ...mockFeatureAppDefinition,
+            dependencies: {
+              externals: {
+                react: '^16.0.0'
+              }
+            }
+          };
+        });
+
+        it("doesn't throw an error", () => {
+          expect(() => {
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
+          }).not.toThrowError();
+        });
+      });
+    });
+
     describe('with an ExternalsValidator provided to the FeatureAppManager', () => {
       beforeEach(() => {
         featureAppManager = new FeatureAppManager(mockFeatureServiceRegistry, {
@@ -204,10 +225,7 @@ describe('FeatureAppManager', () => {
 
         it('calls the provided ExternalsValidator with the defined externals', () => {
           try {
-            featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testIdSpecifier'
-            );
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
           } catch {}
 
           expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
@@ -217,10 +235,7 @@ describe('FeatureAppManager', () => {
 
         it('throws the validation error', () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testIdSpecifier'
-            );
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
           }).toThrowError(mockError);
         });
       });
@@ -238,10 +253,7 @@ describe('FeatureAppManager', () => {
         });
 
         it('calls the provided ExternalsValidator with the defined externals', () => {
-          featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testIdSpecifier'
-          );
+          featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
 
           expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
             react: '^16.0.0'
@@ -250,30 +262,21 @@ describe('FeatureAppManager', () => {
 
         it("doesn't throw an error", () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testIdSpecifier'
-            );
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
           }).not.toThrowError();
         });
       });
 
       describe('with a Feature App definition that declares no externals', () => {
         it('does not call the provided ExternalsValidator', () => {
-          featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testIdSpecifier'
-          );
+          featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
 
           expect(mockExternalsValidator.validate).not.toHaveBeenCalled();
         });
 
         it("doesn't throw an error", () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testIdSpecifier'
-            );
+            featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
           }).not.toThrowError();
         });
       });

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -72,6 +72,7 @@ export interface FeatureAppManagerLike {
 export interface FeatureAppManagerOptions {
   readonly configs?: FeatureAppConfigs;
   readonly moduleLoader?: ModuleLoader;
+  readonly externalsValidator?: ExternalsValidatorLike;
 }
 
 type FeatureAppModuleUrl = string;
@@ -97,7 +98,6 @@ export class FeatureAppManager implements FeatureAppManagerLike {
 
   public constructor(
     private readonly featureServiceRegistry: FeatureServiceRegistryLike,
-    private readonly externalsValidator: ExternalsValidatorLike,
     private readonly options: FeatureAppManagerOptions = {}
   ) {}
 
@@ -299,10 +299,16 @@ export class FeatureAppManager implements FeatureAppManagerLike {
   private validateExternals(
     featureAppDefinition: FeatureServiceConsumerDefinition
   ): void {
+    const {externalsValidator} = this.options;
+
+    if (!externalsValidator) {
+      return;
+    }
+
     const {dependencies} = featureAppDefinition;
 
     if (dependencies && dependencies.externals) {
-      this.externalsValidator.validate(dependencies.externals);
+      externalsValidator.validate(dependencies.externals);
     }
   }
 }

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -88,7 +88,7 @@ export interface FeatureAppManagerOptions {
    * external dependencies that are required by Feature Apps against the
    * shared dependencies that are provided by the integrator. This makes it
    * possible that an error is already thrown when creating a Feature App with
-   * incompatible external dependencies. This enables early feedback as to
+   * incompatible external dependencies, and thus enables early feedback as to
    * whether a Feature App is compatible with the integration environment.
    */
   readonly externalsValidator?: ExternalsValidatorLike;

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -70,8 +70,27 @@ export interface FeatureAppManagerLike {
 }
 
 export interface FeatureAppManagerOptions {
+  /**
+   * Configurations for all Feature Apps that will potentially be created.
+   */
   readonly configs?: FeatureAppConfigs;
+
+  /**
+   * For the `FeatureAppManager` to be able to load Feature Apps from a remote
+   * location, a module loader must be provided, (e.g. the
+   * `@feature-hub/module-loader-amd` package or the
+   * `@feature-hub/module-loader-commonjs` package).
+   */
   readonly moduleLoader?: ModuleLoader;
+
+  /**
+   * When using a {@link #moduleLoader}, it might make sense to validate
+   * external dependencies that are required by Feature Apps against the
+   * shared dependencies that are provided by the integrator. This makes it
+   * possible that an error is already thrown when creating a Feature App with
+   * incompatible external dependencies. This gives the author early feedback as
+   * to whether a Feature App can run in the integration environment.
+   */
   readonly externalsValidator?: ExternalsValidatorLike;
 }
 

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -88,8 +88,8 @@ export interface FeatureAppManagerOptions {
    * external dependencies that are required by Feature Apps against the
    * shared dependencies that are provided by the integrator. This makes it
    * possible that an error is already thrown when creating a Feature App with
-   * incompatible external dependencies. This gives the author early feedback as
-   * to whether a Feature App can run in the integration environment.
+   * incompatible external dependencies. This enables early feedback as to
+   * whether a Feature App is compatible with the integration environment.
    */
   readonly externalsValidator?: ExternalsValidatorLike;
 }

--- a/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
@@ -20,11 +20,10 @@ export default async function renderApp({
   const featureAppNodeUrl = `http://localhost:${port}/feature-app.commonjs.js`;
   const featureServiceRegistry = new FeatureServiceRegistry(externalsValidator);
 
-  const featureAppManager = new FeatureAppManager(
-    featureServiceRegistry,
-    externalsValidator,
-    {moduleLoader: loadCommonJsModule}
-  );
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+    moduleLoader: loadCommonJsModule,
+    externalsValidator
+  });
 
   // In a real-world integrator, instead of preloading a Feature App manually
   // before rendering, the Async SSR Manager would be used to handle the

--- a/packages/demos/src/feature-app-in-feature-app/integrator.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.tsx
@@ -21,11 +21,10 @@ const externalsValidator = new ExternalsValidator({
 
 const featureServiceRegistry = new FeatureServiceRegistry(externalsValidator);
 
-const featureAppManager = new FeatureAppManager(
-  featureServiceRegistry,
-  externalsValidator,
-  {moduleLoader: loadAmdModule}
-);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule,
+  externalsValidator
+});
 
 const {FeatureHubContextProvider, FeatureAppLoader} = FeatureHubReact;
 

--- a/packages/demos/src/history-service/integrator.node.tsx
+++ b/packages/demos/src/history-service/integrator.node.tsx
@@ -27,10 +27,7 @@ export default async function renderApp({
     'test:integrator'
   );
 
-  const featureAppManager = new FeatureAppManager(
-    featureServiceRegistry,
-    externalsValidator
-  );
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry);
 
   const html = ReactDOM.renderToString(
     <App featureAppManager={featureAppManager} />

--- a/packages/demos/src/history-service/integrator.tsx
+++ b/packages/demos/src/history-service/integrator.tsx
@@ -18,10 +18,7 @@ featureServiceRegistry.registerFeatureServices(
   'test:integrator'
 );
 
-const featureAppManager = new FeatureAppManager(
-  featureServiceRegistry,
-  externalsValidator
-);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry);
 
 ReactDOM.render(
   <App featureAppManager={featureAppManager} />,

--- a/packages/demos/src/module-loader-amd/integrator.tsx
+++ b/packages/demos/src/module-loader-amd/integrator.tsx
@@ -17,11 +17,10 @@ const externalsValidator = new ExternalsValidator({
 
 const featureServiceRegistry = new FeatureServiceRegistry(externalsValidator);
 
-const featureAppManager = new FeatureAppManager(
-  featureServiceRegistry,
-  externalsValidator,
-  {moduleLoader: loadAmdModule}
-);
+const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+  moduleLoader: loadAmdModule,
+  externalsValidator
+});
 
 ReactDOM.render(
   <FeatureHubContextProvider value={{featureAppManager}}>

--- a/packages/demos/src/module-loader-commonjs/integrator.node.tsx
+++ b/packages/demos/src/module-loader-commonjs/integrator.node.tsx
@@ -16,11 +16,9 @@ export default async function renderApp({
   const externalsValidator = new ExternalsValidator({});
   const featureServiceRegistry = new FeatureServiceRegistry(externalsValidator);
 
-  const featureAppManager = new FeatureAppManager(
-    featureServiceRegistry,
-    externalsValidator,
-    {moduleLoader: loadCommonJsModule}
-  );
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+    moduleLoader: loadCommonJsModule
+  });
 
   // In a real-world integrator, instead of preloading a Feature App manually
   // before rendering, the Async SSR Manager would be used to handle the

--- a/packages/demos/src/server-side-rendering/integrator.node.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.node.tsx
@@ -53,11 +53,10 @@ export default async function renderApp({
     asyncSsrManagerDefinition.id
   ] as AsyncSsrManagerV0;
 
-  const featureAppManager = new FeatureAppManager(
-    featureServiceRegistry,
-    externalsValidator,
-    {moduleLoader: loadCommonJsModule}
-  );
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+    moduleLoader: loadCommonJsModule,
+    externalsValidator
+  });
 
   const urlsForHydration = new Set<string>();
 

--- a/packages/demos/src/server-side-rendering/integrator.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.tsx
@@ -61,11 +61,10 @@ function getUrlsForHydrationFromDom(): string[] {
     integratorDefinition
   );
 
-  const featureAppManager = new FeatureAppManager(
-    featureServiceRegistry,
-    externalsValidator,
-    {moduleLoader: loadAmdModule}
-  );
+  const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
+    moduleLoader: loadAmdModule,
+    externalsValidator
+  });
 
   const serializedStateManager = featureServices[
     serializedStateManagerDefinition.id


### PR DESCRIPTION
When working on updating the documentation regarding externals, @fahrradflucht and I noticed, while reading the [Module Loader section](https://feature-hub.io/docs/guides/integrating-the-feature-hub#module-loader), that it probably makes more sense to make the `ExternalsValidator` optional, analogous to the optional module loader. Because only when an integrator uses the optional module loader to support loading Feature Apps via URL, it makes sense for him to also validate the externals that he provides for the separately deployed Feature Apps.

**Note:** Making the `ExternalsValidator` optional for the `FeatureServiceRegistry` as is done in a [follow-up PR](https://github.com/sinnerschrader/feature-hub/pull/343).