### PR TITLE
fix(dom): guard against double definition

### DIFF
--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -18,6 +18,8 @@ export interface DomFeatureApp {
   attachTo(container: Element): void;
 }
 
+const elementName = 'feature-app-container';
+
 /**
  * Define a custom element named `feature-app-container` at the
  * `CustomElementRegistry`.
@@ -34,6 +36,10 @@ export interface DomFeatureApp {
 export function defineFeatureAppContainer(
   featureAppManager: FeatureAppManager
 ): void {
+  if (customElements.get(elementName)) {
+    return;
+  }
+
   class FeatureAppContainer extends LitElement {
     @property({type: Object})
     public featureAppDefinition?: FeatureAppDefinition<DomFeatureApp>;
@@ -81,5 +87,5 @@ export function defineFeatureAppContainer(
     }
   }
 
-  customElements.define('feature-app-container', FeatureAppContainer);
+  customElements.define(elementName, FeatureAppContainer);
 }

--- a/packages/dom/src/feature-app-loader.ts
+++ b/packages/dom/src/feature-app-loader.ts
@@ -4,6 +4,8 @@ import {TemplateResult} from 'lit-html';
 import {until} from 'lit-html/directives/until';
 import {defineFeatureAppContainer} from './feature-app-container';
 
+const elementName = 'feature-app-loader';
+
 /**
  * Define a custom element named `feature-app-loader` at the
  * `CustomElementRegistry`.
@@ -22,6 +24,10 @@ import {defineFeatureAppContainer} from './feature-app-container';
 export function defineFeatureAppLoader(
   featureAppManager: FeatureAppManager
 ): void {
+  if (customElements.get(elementName)) {
+    return;
+  }
+
   defineFeatureAppContainer(featureAppManager);
 
   class FeatureAppLoader extends LitElement {
@@ -70,5 +76,5 @@ export function defineFeatureAppLoader(
     }
   }
 
-  customElements.define('feature-app-loader', FeatureAppLoader);
+  customElements.define(elementName, FeatureAppLoader);
 }


### PR DESCRIPTION
If `cutomElements.define` is called mutliple times with the same element name it throws. Since `defineFeatureAppLoader` calls `defineFeatureAppContainer` under the hood, which is something the user doesn't know, we need to guard against `feature-app-container` already being registered. 

To make the behaviour consistent I also added a guard in `defineFeatureAppLoader`.