### PR TITLE
feat(core): define Logger interface and add consoleLogger

### DIFF
--- a/packages/core/src/__tests__/logger.test.ts
+++ b/packages/core/src/__tests__/logger.test.ts
@@ -1,0 +1,71 @@
+// tslint:disable:no-implicit-dependencies
+
+import {Stubbed, stubMethods} from 'jest-stub-methods';
+import {Logger} from '..';
+
+interface LoggerConsoleMaping {
+  loggerMethod: keyof Logger;
+  consoleMethod: keyof Console;
+}
+
+describe('consoleLogger', () => {
+  let stubbedConsole: Stubbed<Console>;
+  let consoleLogger: Logger;
+
+  beforeAll(async () => {
+    stubbedConsole = stubMethods(console);
+
+    // we need to import the consoleLogger after stubbing the console methods
+    // tslint:disable-next-line:no-require-imports
+    consoleLogger = require('..').consoleLogger;
+  });
+
+  afterAll(() => {
+    stubbedConsole.restore();
+  });
+
+  describe('#trace', () => {
+    it('delegates to console.trace', () => {
+      consoleLogger.trace('test');
+
+      expect(stubbedConsole.stub.trace.mock.calls).toEqual([['test']]);
+    });
+  });
+
+  const loggerConsoleMappings: LoggerConsoleMaping[] = [
+    {loggerMethod: 'trace', consoleMethod: 'trace'},
+    {loggerMethod: 'debug', consoleMethod: 'debug'},
+    {loggerMethod: 'info', consoleMethod: 'info'},
+    {loggerMethod: 'warn', consoleMethod: 'warn'},
+    {loggerMethod: 'error', consoleMethod: 'error'},
+    {loggerMethod: 'fatal', consoleMethod: 'error'}
+  ];
+
+  for (const {loggerMethod, consoleMethod} of loggerConsoleMappings) {
+    describe(`#${loggerMethod}`, () => {
+      it(`delegates to console.${consoleMethod}`, () => {
+        consoleLogger[loggerMethod]('test');
+
+        expect(stubbedConsole.stub[consoleMethod].mock.calls).toEqual([
+          ['test']
+        ]);
+      });
+
+      it('preserves the call stack', () => {
+        stubbedConsole.stub[consoleMethod].mockImplementationOnce(() => {
+          throw new Error(
+            `mock error for ${JSON.stringify({loggerMethod, consoleMethod})}`
+          );
+        });
+
+        expect.assertions(1);
+
+        try {
+          consoleLogger[loggerMethod]('test');
+        } catch (error) {
+          expect(error.stack).not.toMatch(/logger\.js/);
+        }
+      });
+    });
+  }
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './create-feature-hub';
 export * from './externals-validator';
 export * from './feature-app-manager';
 export * from './feature-service-registry';
+export * from './logger';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,17 @@
+export interface Logger {
+  trace(message?: unknown, ...optionalParams: unknown[]): void;
+  debug(message?: unknown, ...optionalParams: unknown[]): void;
+  info(message?: unknown, ...optionalParams: unknown[]): void;
+  warn(message?: unknown, ...optionalParams: unknown[]): void;
+  error(message?: unknown, ...optionalParams: unknown[]): void;
+  fatal(message?: unknown, ...optionalParams: unknown[]): void;
+}
+
+export const consoleLogger: Logger = {
+  trace: console.trace.bind(console),
+  debug: console.debug.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  fatal: console.error.bind(console)
+};


### PR DESCRIPTION
**Up for discussion:** If we decide to drop the `fatal` method (do we know a use case?)\* we don't even need the `consoleLogger`. Consumers could instead pass `console` directly where `Logger` is expected.

\* Bunyan describes `fatal` like this: "The service/app is going to stop or become unusable now. An operator should definitely look into this soon."