### PR TITLE
feat(history-service): use Logger Feature Service instead of console

### DIFF
--- a/packages/history-service/package.json
+++ b/packages/history-service/package.json
@@ -22,6 +22,7 @@
   "typings": "lib/cjs/index.d.ts",
   "dependencies": {
     "@feature-hub/core": "^1.1.0",
+    "@feature-hub/logger": "^0.0.0",
     "@feature-hub/server-request": "^1.1.0",
     "fast-deep-equal": "^2.0.1"
   },

--- a/packages/history-service/src/__tests__/stubbed-logger.ts
+++ b/packages/history-service/src/__tests__/stubbed-logger.ts
@@ -1,0 +1,12 @@
+// tslint:disable:no-implicit-dependencies
+
+import {Logger} from '@feature-hub/logger';
+import {Stub} from 'jest-stub-methods';
+
+export const stubbedLogger: Stub<Logger> = {
+  trace: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+};

--- a/packages/history-service/src/internal/browser-consumer-history.ts
+++ b/packages/history-service/src/internal/browser-consumer-history.ts
@@ -2,6 +2,7 @@ import equal from 'fast-deep-equal';
 import * as history from 'history';
 import {ConsumerHistory} from './consumer-history';
 import {HistoryMultiplexer} from './history-multiplexer';
+import {HistoryServiceContext} from './history-service-context';
 
 export class BrowserConsumerHistory extends ConsumerHistory {
   private readonly listeners = new Set<history.LocationListener>();
@@ -9,10 +10,11 @@ export class BrowserConsumerHistory extends ConsumerHistory {
   private readonly browserUnregister: () => void;
 
   public constructor(
+    context: HistoryServiceContext,
     consumerUid: string,
     historyMultiplexer: HistoryMultiplexer
   ) {
-    super(consumerUid, historyMultiplexer);
+    super(context, consumerUid, historyMultiplexer);
 
     this.browserUnregister = historyMultiplexer.listenForPop(() => {
       this.handlePop();

--- a/packages/history-service/src/internal/consumer-history.ts
+++ b/packages/history-service/src/internal/consumer-history.ts
@@ -1,11 +1,13 @@
 import * as history from 'history';
 import {HistoryMultiplexer} from './history-multiplexer';
+import {HistoryServiceContext} from './history-service-context';
 
 export abstract class ConsumerHistory implements history.History {
   public action: history.Action = 'POP';
   public location: history.Location;
 
   public constructor(
+    protected readonly context: HistoryServiceContext,
     protected readonly consumerUid: string,
     protected readonly historyMultiplexer: HistoryMultiplexer
   ) {
@@ -56,19 +58,19 @@ export abstract class ConsumerHistory implements history.History {
   }
 
   public go(): void {
-    console.warn('history.go() is not supported.');
+    this.context.logger.warn('history.go() is not supported.');
   }
 
   public goBack(): void {
-    console.warn('history.goBack() is not supported.');
+    this.context.logger.warn('history.goBack() is not supported.');
   }
 
   public goForward(): void {
-    console.warn('history.goForward() is not supported.');
+    this.context.logger.warn('history.goForward() is not supported.');
   }
 
   public block(): history.UnregisterCallback {
-    console.warn('history.block() is not supported.');
+    this.context.logger.warn('history.block() is not supported.');
 
     return () => undefined;
   }

--- a/packages/history-service/src/internal/create-history-multiplexers.ts
+++ b/packages/history-service/src/internal/create-history-multiplexers.ts
@@ -1,7 +1,7 @@
-import {ServerRequestV1} from '@feature-hub/server-request';
 import * as history from 'history';
 import {RootLocationTransformer} from '../create-root-location-transformer';
 import {HistoryMultiplexer} from './history-multiplexer';
+import {HistoryServiceContext} from './history-service-context';
 import {StaticRootHistory} from './static-root-history';
 
 export interface HistoryMultiplexers {
@@ -10,8 +10,8 @@ export interface HistoryMultiplexers {
 }
 
 export function createHistoryMultiplexers(
-  rootLocationTransformer: RootLocationTransformer,
-  serverRequest?: ServerRequestV1
+  context: HistoryServiceContext,
+  rootLocationTransformer: RootLocationTransformer
 ): HistoryMultiplexers {
   let browserHistoryMultiplexer: HistoryMultiplexer | undefined;
   let staticHistoryMultiplexer: HistoryMultiplexer | undefined;
@@ -30,14 +30,14 @@ export function createHistoryMultiplexers(
 
     get staticHistoryMultiplexer(): HistoryMultiplexer {
       if (!staticHistoryMultiplexer) {
-        if (!serverRequest) {
+        if (!context.serverRequest) {
           throw new Error(
             'Static history can not be created without a server request.'
           );
         }
 
         staticHistoryMultiplexer = new HistoryMultiplexer(
-          new StaticRootHistory(serverRequest),
+          new StaticRootHistory(context.serverRequest),
           rootLocationTransformer
         );
       }

--- a/packages/history-service/src/internal/create-history-service-v1-binder.ts
+++ b/packages/history-service/src/internal/create-history-service-v1-binder.ts
@@ -3,9 +3,11 @@ import * as history from 'history';
 import {HistoryServiceV1} from '../define-history-service';
 import {BrowserConsumerHistory} from './browser-consumer-history';
 import {HistoryMultiplexers} from './create-history-multiplexers';
+import {HistoryServiceContext} from './history-service-context';
 import {StaticConsumerHistory} from './static-consumer-history';
 
 export function createHistoryServiceV1Binder(
+  context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers
 ): FeatureServiceBinder<HistoryServiceV1> {
   return (consumerUid: string): FeatureServiceBinding<HistoryServiceV1> => {
@@ -15,13 +17,14 @@ export function createHistoryServiceV1Binder(
     const featureService: HistoryServiceV1 = {
       createBrowserHistory: () => {
         if (browserConsumerHistory) {
-          console.warn(
+          context.logger.warn(
             `createBrowserHistory was called multiple times by consumer ${JSON.stringify(
               consumerUid
             )}. Returning the same history instance as before.`
           );
         } else {
           browserConsumerHistory = new BrowserConsumerHistory(
+            context,
             consumerUid,
             historyMultiplexers.browserHistoryMultiplexer
           );
@@ -32,13 +35,14 @@ export function createHistoryServiceV1Binder(
 
       createStaticHistory: () => {
         if (staticConsumerHistory) {
-          console.warn(
+          context.logger.warn(
             `createStaticHistory was called multiple times by consumer ${JSON.stringify(
               consumerUid
             )}. Returning the same history instance as before.`
           );
         } else {
           staticConsumerHistory = new StaticConsumerHistory(
+            context,
             consumerUid,
             historyMultiplexers.staticHistoryMultiplexer
           );

--- a/packages/history-service/src/internal/history-service-context.ts
+++ b/packages/history-service/src/internal/history-service-context.ts
@@ -1,0 +1,17 @@
+import {Logger} from '@feature-hub/logger';
+import {ServerRequestV1} from '@feature-hub/server-request';
+import {HistoryServiceDependencies} from '../define-history-service';
+
+export interface HistoryServiceContext {
+  logger: Logger;
+  serverRequest?: ServerRequestV1;
+}
+
+export function createHistoryServiceContext(
+  featureServices: HistoryServiceDependencies
+): HistoryServiceContext {
+  const logger = featureServices['s2:logger'] || console;
+  const serverRequest = featureServices['s2:server-request'];
+
+  return {logger, serverRequest};
+}

--- a/packages/history-service/src/internal/static-consumer-history.ts
+++ b/packages/history-service/src/internal/static-consumer-history.ts
@@ -3,7 +3,7 @@ import {ConsumerHistory} from './consumer-history';
 
 export class StaticConsumerHistory extends ConsumerHistory {
   public listen(): history.UnregisterCallback {
-    console.warn('history.listen() is not supported.');
+    this.context.logger.warn('history.listen() is not supported.');
 
     return () => undefined;
   }


### PR DESCRIPTION
The integrator can now provide the Logger Feature Service, which the History Service then uses for logging. The History Service declares the Logger Feature Service as an optional dependency, and uses `console` as a fallback logger, when the Logger Feature Service is not provided.