### PR TITLE
feat(async-ssr-manager): use Logger Feature Service instead of console

### DIFF
--- a/packages/async-ssr-manager/package.json
+++ b/packages/async-ssr-manager/package.json
@@ -21,7 +21,8 @@
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index.d.ts",
   "dependencies": {
-    "@feature-hub/core": "^1.1.0"
+    "@feature-hub/core": "^1.1.0",
+    "@feature-hub/logger": "^0.0.0"
   },
   "devDependencies": {
     "jest-stub-methods": "^0.2.1"

--- a/packages/async-ssr-manager/src/__tests__/stubbed-logger.ts
+++ b/packages/async-ssr-manager/src/__tests__/stubbed-logger.ts
@@ -1,0 +1,12 @@
+// tslint:disable:no-implicit-dependencies
+
+import {Logger} from '@feature-hub/logger';
+import {Stub} from 'jest-stub-methods';
+
+export const stubbedLogger: Stub<Logger> = {
+  trace: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+};

--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -87,7 +87,7 @@ export interface SharedAsyncSsrManager extends SharedFeatureService {
 }
 
 export interface AsyncSsrManagerDependencies extends FeatureServices {
-  's2:logger'?: Logger;
+  readonly 's2:logger'?: Logger;
 }
 
 /**

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
@@ -1,0 +1,14 @@
+import {Logger} from '@feature-hub/logger';
+import {AsyncSsrManagerDependencies} from '..';
+
+export interface AsyncSsrManagerContext {
+  logger: Logger;
+}
+
+export function createAsyncSsrManagerContext(
+  featureServices: AsyncSsrManagerDependencies
+): AsyncSsrManagerContext {
+  const logger = featureServices['s2:logger'] || console;
+
+  return {logger};
+}

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
@@ -2,7 +2,7 @@ import {Logger} from '@feature-hub/logger';
 import {AsyncSsrManagerDependencies} from '..';
 
 export interface AsyncSsrManagerContext {
-  logger: Logger;
+  readonly logger: Logger;
 }
 
 export function createAsyncSsrManagerContext(

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -1,4 +1,5 @@
 import {AsyncSsrManagerV1} from '..';
+import {AsyncSsrManagerContext} from './async-ssr-manager-context';
 import {setTimeoutAsync} from './set-timeout-async';
 
 async function renderingTimeout(timeout: number): Promise<never> {
@@ -10,13 +11,16 @@ async function renderingTimeout(timeout: number): Promise<never> {
 export class AsyncSsrManager implements AsyncSsrManagerV1 {
   private readonly asyncOperations = new Set<Promise<unknown>>();
 
-  public constructor(private readonly timeout?: number) {}
+  public constructor(
+    private readonly context: AsyncSsrManagerContext,
+    private readonly timeout?: number
+  ) {}
 
   public async renderUntilCompleted(render: () => string): Promise<string> {
     const renderPromise = this.renderingLoop(render);
 
     if (typeof this.timeout !== 'number') {
-      console.warn(
+      this.context.logger.warn(
         'No timeout is configured for the Async SSR Manager. This could lead to unexpectedly long render times or, in the worst case, never resolving render calls!'
       );
 
@@ -38,7 +42,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     while (this.asyncOperations.size > 0) {
       while (this.asyncOperations.size > 0) {
         // Storing a snapshot of the asynchronous operations and clearing them
-        // afterwards allows that consecutive promises can be added while the
+        // afterwards, allows that consecutive promises can be added while the
         // current asynchronous operations are running.
 
         const asyncOperationsSnapshot = Array.from(


### PR DESCRIPTION
The integrator can now provide the Logger Feature Service, which the Async SSR Manager then uses for logging. The Async SSR Manager declares the Logger Feature Service as an optional dependency, and uses `console` as a fallback logger, when the Logger Feature Service is not provided.