### PR TITLE
feat(dom): allow for container replacement

### DIFF
--- a/packages/demos/src/integrator-dom/feature-app.ts
+++ b/packages/demos/src/integrator-dom/feature-app.ts
@@ -6,7 +6,7 @@ const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
 
   create: () => ({
     attachTo(element: HTMLElement): void {
-      element.innerHTML = 'Hello, World!';
+      element.replaceWith('Hello, World!');
     }
   })
 };

--- a/packages/demos/src/integrator-dom/index.test.ts
+++ b/packages/demos/src/integrator-dom/index.test.ts
@@ -33,7 +33,7 @@ describe('integration test: "dom integrator"', () => {
   describe('if the Feature App loads successfully', () => {
     it('renders the Feature App', async () => {
       const handle = await page.evaluateHandle(
-        'document.querySelector("feature-app-loader").shadowRoot.querySelector("feature-app-container").shadowRoot.querySelector("div")'
+        'document.querySelector("feature-app-loader").shadowRoot.querySelector("feature-app-container").shadowRoot'
       );
 
       await expect(handle).toMatch('Hello, World!');


### PR DESCRIPTION
Previously Feature Apps could only render into the provided container element but would not be rendered if they replaced it. Now this is possible as well.