### PR TITLE
test(react): suppress react's error boundary development logs

### DIFF
--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -16,8 +16,10 @@ describe('FeatureAppContainer', () => {
   let mockGetFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
+  let stubbedConsole: Stubbed<Console>;
 
   beforeEach(() => {
+    stubbedConsole = stubMethods(console);
     mockFeatureAppDefinition = {id: 'testId', create: jest.fn()};
     mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
     mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
@@ -27,6 +29,10 @@ describe('FeatureAppContainer', () => {
       getFeatureAppScope: mockGetFeatureAppScope,
       preloadFeatureApp: jest.fn()
     } as Partial<FeatureAppManager>) as FeatureAppManager;
+  });
+
+  afterEach(() => {
+    stubbedConsole.restore();
   });
 
   it('throws an error when rendered without a FeatureHubContextProvider', () => {
@@ -441,16 +447,6 @@ describe('FeatureAppContainer', () => {
   });
 
   describe('without a custom logger', () => {
-    let stubbedConsole: Stubbed<Console>;
-
-    beforeEach(() => {
-      stubbedConsole = stubMethods(console);
-    });
-
-    afterEach(() => {
-      stubbedConsole.restore();
-    });
-
     it('logs messages using the console', () => {
       const mockError = new Error('Failed to render.');
 

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -27,8 +27,11 @@ describe('FeatureAppLoader', () => {
   let mockAsyncFeatureAppDefinition: AsyncValue<FeatureAppDefinition<unknown>>;
   let mockAsyncSsrManager: MockAsyncSsrManager;
   let mockAddUrlForHydration: jest.Mock;
+  let stubbedConsole: Stubbed<Console>;
 
   beforeEach(() => {
+    stubbedConsole = stubMethods(console);
+
     if (document.head) {
       document.head.innerHTML = '';
     }
@@ -53,6 +56,10 @@ describe('FeatureAppLoader', () => {
     };
 
     mockAddUrlForHydration = jest.fn();
+  });
+
+  afterEach(() => {
+    stubbedConsole.restore();
   });
 
   it('throws an error when rendered without a FeatureHubContextProvider', () => {
@@ -341,16 +348,6 @@ describe('FeatureAppLoader', () => {
   });
 
   describe('without a custom logger', () => {
-    let stubbedConsole: Stubbed<Console>;
-
-    beforeEach(() => {
-      stubbedConsole = stubMethods(console);
-    });
-
-    afterEach(() => {
-      stubbedConsole.restore();
-    });
-
     it('logs messages using the console', () => {
       const mockError = new Error('Failed to load Feature App module.');
 


### PR DESCRIPTION
We don't want the error logs in our test output.