### PR TITLE
fix(module-loader-commonjs): avoid require cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .node-version
 .nvmrc
+.tmp
 coverage
 lerna-debug.log
 lib

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .cache
+.tmp
 CHANGELOG.md
 coverage
 lib

--- a/rcgen.js
+++ b/rcgen.js
@@ -13,6 +13,7 @@ exports.default = composeManifest(
   git(),
   gitIgnoreFiles(
     '.cache',
+    '.tmp',
     'coverage',
     'lerna-debug.log',
     'lib',


### PR DESCRIPTION
While server-side rendering Feature Apps in development mode, no changes to the Feature App code are visible in the rendered html, since the Feature App server bundle is always loaded from the require cache while the server is running. This fix ensures that no stale version of a fetched module is loaded from the require cache.