### PR TITLE
feat(react): support adding Feature App stylesheets to the document during SSR

### DIFF
--- a/docs/guides/server-side-rendering.md
+++ b/docs/guides/server-side-rendering.md
@@ -129,9 +129,9 @@ await Promise.all(
 
 ### Using React
 
-A React integrator can use the `FeatureHubContextProvider` to provide a callback
-that is called by the `FeatureAppLoader` for server-rendered Feature Apps to
-populate a set of URLs on the server for hydration on the client:
+On the server, a React integrator can use the `FeatureHubContextProvider` to
+provide a callback that is called by the `FeatureAppLoader` for server-rendered
+Feature Apps to populate a set of URLs for hydration on the client:
 
 ```js
 const urlsForHydration = new Set();
@@ -140,6 +140,38 @@ const addUrlForHydration = url => urlsForHydration.add(url);
 
 ```jsx
 <FeatureHubContextProvider value={{featureAppManager, addUrlForHydration}}>
+  {/* render Feature Apps here */}
+</FeatureHubContextProvider>
+```
+
+## Adding Stylesheets to the Document
+
+When a Feature App has been rendered on the server, and there are [external
+stylesheets defined for this Feature App][feature-app-loader-css], those
+stylesheets should be added to the document head, before sending the HTML to the
+client. This allows the browser to render the Feature App HTML with the
+corresponding styles before all the scripts have been loaded and the
+server-rendered page has been hydrated.
+
+### Using React
+
+On the server, a React integrator can use the `FeatureHubContextProvider` to
+provide a callback that is called by the `FeatureAppLoader` for server-rendered
+Feature Apps to populate a collection of stylesheets that should be added to the
+document head:
+
+```js
+const stylesheetsForSsr = new Map();
+
+const addStylesheetsForSsr = stylesheets => {
+  for (const stylesheet of stylesheets) {
+    stylesheetsForSsr.set(stylesheet.href, stylesheet);
+  }
+};
+```
+
+```jsx
+<FeatureHubContextProvider value={{featureAppManager, addStylesheetsForSsr}}>
   {/* render Feature Apps here */}
 </FeatureHubContextProvider>
 ```
@@ -304,3 +336,4 @@ const html = await asyncSsrManager.renderUntilCompleted(() =>
   /docs/guides/integrating-the-feature-hub#consuming-feature-services
 [server-side-rendering-demo]:
   https://github.com/sinnerschrader/feature-hub/tree/master/packages/demos/src/server-side-rendering
+[feature-app-loader-css]: /docs/guides/integrating-the-feature-hub#css

--- a/packages/demos/README.md
+++ b/packages/demos/README.md
@@ -71,6 +71,8 @@ Demonstrates:
   server-rendered Feature Apps to the client
 - how server-rendered Feature Apps can be preloaded in the client before
   hydration
+- how external stylesheets of Feature Apps can be added to the document during
+  SSR
 
 ```sh
 yarn watch:demo server-side-rendering

--- a/packages/demos/src/server-side-rendering/app.tsx
+++ b/packages/demos/src/server-side-rendering/app.tsx
@@ -10,6 +10,11 @@ export function App({port}: AppProps): JSX.Element {
     <FeatureAppLoader
       src="feature-app.umd.js"
       serverSrc={port ? `http://localhost:${port}/feature-app.commonjs.js` : ''}
+      css={[
+        {href: 'normalize.css'},
+        {href: 'blueprint-icons.css'},
+        {href: 'blueprint.css'}
+      ]}
     />
   );
 }

--- a/packages/demos/src/server-side-rendering/integrator.node.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.node.tsx
@@ -5,6 +5,7 @@ import {
 import {createFeatureHub} from '@feature-hub/core';
 import {loadCommonJsModule} from '@feature-hub/module-loader-commonjs';
 import {
+  Css,
   FeatureHubContextProvider,
   FeatureHubContextProviderValue
 } from '@feature-hub/react';
@@ -42,13 +43,18 @@ export default async function renderApp({
   ] as AsyncSsrManagerV1;
 
   const urlsForHydration = new Set<string>();
+  const stylesheetsForSsr = new Map<string, Css>();
 
   const featureHubContextValue: FeatureHubContextProviderValue = {
     featureAppManager,
     asyncSsrManager,
 
-    addUrlForHydration(url: string): void {
-      urlsForHydration.add(url);
+    addUrlForHydration: url => urlsForHydration.add(url),
+
+    addStylesheetsForSsr: stylesheets => {
+      for (const stylesheet of stylesheets) {
+        stylesheetsForSsr.set(stylesheet.href, stylesheet);
+      }
     }
   };
 
@@ -66,5 +72,5 @@ export default async function renderApp({
 
   const serializedStates = serializedStateManager.serializeStates();
 
-  return {html, serializedStates, urlsForHydration};
+  return {html, serializedStates, stylesheetsForSsr, urlsForHydration};
 }

--- a/packages/demos/src/server-side-rendering/integrator.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.tsx
@@ -7,7 +7,6 @@ import {
 } from '@feature-hub/serialized-state-manager';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import '../blueprint-css';
 import {App} from './app';
 
 function getSerializedStatesFromDom(): string | undefined {

--- a/packages/demos/src/server-side-rendering/webpack-config.js
+++ b/packages/demos/src/server-side-rendering/webpack-config.js
@@ -1,4 +1,5 @@
 // @ts-check
+const CopyPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
@@ -38,7 +39,16 @@ const configs = [
     output: {
       filename: 'integrator.js',
       publicPath: '/'
-    }
+    },
+    plugins: [
+      new CopyPlugin(
+        [
+          'normalize.css/normalize.css',
+          '@blueprintjs/icons/lib/css/blueprint-icons.css',
+          '@blueprintjs/core/lib/css/blueprint.css'
+        ].map(cssPath => ({from: require.resolve(cssPath)}))
+      )
+    ]
   })
 ];
 

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -28,6 +28,7 @@ describe('FeatureAppLoader', () => {
   let mockAsyncFeatureAppDefinition: AsyncValue<FeatureAppDefinition<unknown>>;
   let mockAsyncSsrManager: MockAsyncSsrManager;
   let mockAddUrlForHydration: jest.Mock;
+  let mockAddStylesheetsForSsr: jest.Mock;
   let stubbedConsole: Stubbed<Console>;
 
   const usingTestErrorBoundaryConsoleErrorCalls = [
@@ -83,6 +84,7 @@ describe('FeatureAppLoader', () => {
     };
 
     mockAddUrlForHydration = jest.fn();
+    mockAddStylesheetsForSsr = jest.fn();
   });
 
   afterEach(() => {
@@ -114,6 +116,7 @@ describe('FeatureAppLoader', () => {
           featureAppManager: mockFeatureAppManager,
           asyncSsrManager: mockAsyncSsrManager,
           addUrlForHydration: mockAddUrlForHydration,
+          addStylesheetsForSsr: mockAddStylesheetsForSsr,
           logger: customLogger ? logger : undefined
         }}
       >
@@ -149,6 +152,12 @@ describe('FeatureAppLoader', () => {
 
       expect(document.head).toMatchSnapshot();
     });
+
+    it('does not try to add stylesheets for SSR', () => {
+      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+
+      expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
+    });
   });
 
   describe('with a css prop', () => {
@@ -161,6 +170,14 @@ describe('FeatureAppLoader', () => {
       );
 
       expect(document.head).toMatchSnapshot();
+    });
+
+    it('does not add the stylesheets for SSR', () => {
+      renderWithFeatureHubContext(
+        <FeatureAppLoader src="example.js" css={[{href: 'foo.css'}]} />
+      );
+
+      expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
     });
 
     describe('when the css has already been appended', () => {

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -2,14 +2,10 @@ import {FeatureAppDefinition} from '@feature-hub/core';
 import * as React from 'react';
 import {FeatureAppContainer} from './feature-app-container';
 import {
+  Css,
   FeatureHubContextConsumer,
   FeatureHubContextConsumerValue
 } from './feature-hub-context';
-
-export interface Css {
-  readonly href: string;
-  readonly media?: string;
-}
 
 export interface FeatureAppLoaderProps {
   /**
@@ -75,8 +71,10 @@ class InternalFeatureAppLoader extends React.PureComponent<
       featureAppManager,
       src: clientSrc,
       serverSrc,
+      css,
       asyncSsrManager,
-      addUrlForHydration
+      addUrlForHydration,
+      addStylesheetsForSsr
     } = props;
 
     const src = inBrowser ? clientSrc : serverSrc;
@@ -91,6 +89,10 @@ class InternalFeatureAppLoader extends React.PureComponent<
 
     if (!inBrowser && addUrlForHydration) {
       addUrlForHydration(clientSrc);
+    }
+
+    if (!inBrowser && css && addStylesheetsForSsr) {
+      addStylesheetsForSsr(css);
     }
 
     const {

--- a/packages/react/src/feature-hub-context.tsx
+++ b/packages/react/src/feature-hub-context.tsx
@@ -5,6 +5,11 @@ import * as React from 'react';
 type SomeRequired<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> &
   Required<Pick<T, K>>;
 
+export interface Css {
+  readonly href: string;
+  readonly media?: string;
+}
+
 export interface FeatureHubContextProviderValue {
   /**
    * The `FeatureAppManager` singleton instance.
@@ -32,6 +37,18 @@ export interface FeatureHubContextProviderValue {
    * @param url The client URL of a Feature App that is rendered on the server.
    */
   addUrlForHydration?(url: string): void;
+
+  /**
+   * A callback that the integrator provides on the server, mainly for the
+   * [[FeatureAppLoader]], to add stylesheets for those Feature Apps that are
+   * rendered on the server, so that they can be added to the document before
+   * being sent to the client. Calling it more than once with the same `href`
+   * must not have any impact.
+   *
+   * @param stylesheets A list of stylesheets for a Feature App that is rendered
+   * on the server.
+   */
+  addStylesheetsForSsr?(stylesheets: Css[]): void;
 }
 
 /**


### PR DESCRIPTION
With this feature, the integrator can prevent flickering when a server-rendered Feature App with external stylesheets is hydrated in the browser.

Normally, in the client, the `FeatureAppLoader` appends the stylesheets after it has been mounted. Since the integrator usually preloads Feature App client bundles before starting the hydration, the server-rendered Feature App HTML is displayed unstyled until the integrator client bundle as well as all Feature App client bundles have been loaded and evaluated.

Now, the integrator can collect all stylesheets during SSR, and append link elements for them to the document head, before sending the HTML to the client. This allows the browser to immediately load theses stylesheets before rendering the DOM, and thus prevents any flickering caused by missing styles.

Thanks for reporting this issue, @elbkind!

[Docs](https://deploy-preview-452--feature-hub.netlify.com/docs/guides/server-side-rendering#adding-stylesheets-to-the-document)