### PR TITLE
ci(all): run two integration tests at once to avoid memory leak issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - '10'
   - '8'
 cache: yarn
+env:
+  - TEST_SUITE=unit
+  - TEST_SUITE=integration
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ node_js:
   - '10'
   - '8'
 cache: yarn
-env:
-  - TEST_SUITE=unit
-  - TEST_SUITE=integration
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "sort-package-jsons": "sort-package-json package.json packages/*/package.json",
     "pretest": "rimraf coverage",
     "test": "jest --verbose",
+    "test:integration": "jest --verbose --testPathPattern packages/demos",
+    "test:unit": "jest --verbose --testPathIgnorePatterns packages/demos",
     "verify": "run-p verify:**",
     "verify:format": "prettier --list-different '**/*.{js,json,md,ts,tsx,yml}'",
     "verify:install": "git diff --exit-code yarn.lock",

--- a/scripts/ci/test-azure.sh
+++ b/scripts/ci/test-azure.sh
@@ -6,7 +6,8 @@ set -e
 
 yarn commitlint-azure-pipelines
 
-yarn test --no-cache --maxWorkers 2 --no-verbose
+yarn test:unit --no-cache --maxWorkers 2 --no-verbose
+find packages/demos -iname '*test.ts*' | xargs -n 2 yarn jest --no-cache --no-verbose --no-coverage --maxWorkers 2
 yarn lint
 yarn compile
 yarn verify

--- a/scripts/ci/test-travis.sh
+++ b/scripts/ci/test-travis.sh
@@ -2,11 +2,16 @@
 
 set -e
 
-./scripts/ci/word-blacklist.sh
+if [ "$TEST_SUITE" = "unit" ]
+then
+  ./scripts/ci/word-blacklist.sh
 
-yarn commitlint-travis
+  yarn commitlint-travis
 
-yarn test --no-cache --maxWorkers 2 --no-verbose
-yarn lint
-yarn compile
-yarn verify
+  yarn test:$TEST_SUITE --no-cache --maxWorkers 2 --no-verbose
+  yarn lint
+  yarn compile
+  yarn verify
+else
+  yarn test:$TEST_SUITE --no-cache --runInBand --logHeapUsage --no-verbose
+fi

--- a/scripts/ci/test-travis.sh
+++ b/scripts/ci/test-travis.sh
@@ -7,7 +7,7 @@ set -e
 yarn commitlint-travis
 
 yarn test:unit --no-cache --maxWorkers 2 --no-verbose
-node --max_old_space_size=4096 $(npm bin)/jest --no-cache --maxWorkers 2 --no-verbose --no-coverage --logHeapUsage --testPathPattern packages/demos
+find packages/demos -iname '*test.ts*' | xargs -n 2 yarn jest --no-cache --no-verbose --no-coverage --maxWorkers 2
 yarn lint
 yarn compile
 yarn verify

--- a/scripts/ci/test-travis.sh
+++ b/scripts/ci/test-travis.sh
@@ -8,10 +8,10 @@ then
 
   yarn commitlint-travis
 
-  yarn test:$TEST_SUITE --no-cache --maxWorkers 2 --no-verbose
+  yarn test:unit --no-cache --maxWorkers 2 --no-verbose
   yarn lint
   yarn compile
   yarn verify
 else
-  yarn test:$TEST_SUITE --no-cache --runInBand --logHeapUsage --no-verbose
+  node --max_old_space_size=4096 $(npm bin)/jest --no-cache --maxWorkers 2 --no-verbose --no-coverage --logHeapUsage --testPathPattern packages/demos
 fi

--- a/scripts/ci/test-travis.sh
+++ b/scripts/ci/test-travis.sh
@@ -2,16 +2,12 @@
 
 set -e
 
-if [ "$TEST_SUITE" = "unit" ]
-then
-  ./scripts/ci/word-blacklist.sh
+./scripts/ci/word-blacklist.sh
 
-  yarn commitlint-travis
+yarn commitlint-travis
 
-  yarn test:unit --no-cache --maxWorkers 2 --no-verbose
-  yarn lint
-  yarn compile
-  yarn verify
-else
-  node --max_old_space_size=4096 $(npm bin)/jest --no-cache --maxWorkers 2 --no-verbose --no-coverage --logHeapUsage --testPathPattern packages/demos
-fi
+yarn test:unit --no-cache --maxWorkers 2 --no-verbose
+node --max_old_space_size=4096 $(npm bin)/jest --no-cache --maxWorkers 2 --no-verbose --no-coverage --logHeapUsage --testPathPattern packages/demos
+yarn lint
+yarn compile
+yarn verify


### PR DESCRIPTION
Jest with webpack has known memory leaks, see facebook/jest#6399 for details. To put a bandaid on this issue, we run only two integration tests at once in the CI so that we don't run out of memory and still can add more integration tests later (vs. increasing `max_old_space_size`).