### PR TITLE
ci(all): force exit on integration tests

### DIFF
--- a/scripts/ci/test-azure.sh
+++ b/scripts/ci/test-azure.sh
@@ -3,11 +3,5 @@
 set -e
 
 ./scripts/ci/word-blacklist.sh
-
 yarn commitlint-azure-pipelines
-
-yarn test:unit --no-cache --maxWorkers 2 --no-verbose
-find packages/demos -iname '*test.ts*' | xargs -n 2 yarn jest --no-cache --no-verbose --no-coverage --maxWorkers 2
-yarn lint
-yarn compile
-yarn verify
+./scripts/ci/test.sh

--- a/scripts/ci/test-travis.sh
+++ b/scripts/ci/test-travis.sh
@@ -3,11 +3,5 @@
 set -e
 
 ./scripts/ci/word-blacklist.sh
-
 yarn commitlint-travis
-
-yarn test:unit --no-cache --maxWorkers 2 --no-verbose
-find packages/demos -iname '*test.ts*' | xargs -n 2 yarn jest --no-cache --no-verbose --no-coverage --maxWorkers 2
-yarn lint
-yarn compile
-yarn verify
+./scripts/ci/test.sh

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+yarn test:unit --no-cache --maxWorkers 2 --no-verbose
+find packages/demos -iname '*test.ts*' | xargs -n 2 yarn jest --no-cache --no-verbose --no-coverage --maxWorkers 2 --forceExit
+yarn lint
+yarn compile
+yarn verify


### PR DESCRIPTION
This is needed when there are is an odd number of integration tests. In this case the last one is run alone and jest stalls with this error:

> Jest did not exit one second after the test run has completed.
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

[Stalled pipeline example](https://dev.azure.com/feature-hub/feature-hub/_build/results?buildId=51)