### PR TITLE
build(demos): update @types/styled-components

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,1 @@
+@types/react-native

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -23,7 +23,7 @@
     "@types/get-port": "^4.0.0",
     "@types/history": "^4.7.2",
     "@types/pino": "^5.8.5",
-    "@types/styled-components": "4.1.8",
+    "@types/styled-components": "^4.1.14",
     "@types/webpack": "^4.4.20",
     "@types/webpack-dev-middleware": "^2.0.2",
     "@types/webpack-merge": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,6 +2113,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@*":
+  version "0.57.51"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.57.51.tgz#adcb02141734b72822848351be734971e508f5f1"
+  integrity sha512-0LkXPeV1Hn+5zZ0BE6RBrBJTpM2P4S+306H9lKdi220PHFwMtHt1k8SiQpqUA2yjpi+c6pFIq6H2zZGusPHT9w==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react-test-renderer@^16.0.3":
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.8.1.tgz#96f3ce45a3a41c94eca532a99103dd3042c9d055"
@@ -2161,13 +2169,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-components@4.1.8":
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.8.tgz#15c8a53bb4b9066e528fafb7558963dee5690ae0"
-  integrity sha512-NrG0wmB9Rafy5i00GFxUM/uEge148bX2QPr+Q/MI2fXrew6WOp1hN2A3YEG0AeT45z47CMdJ3BEffPsdQCWayA==
+"@types/styled-components@^4.1.14":
+  version "4.1.14"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.14.tgz#fe029b0bfb2d26af7f9bd4dd4811b31961ff6d49"
+  integrity sha512-X5t+uomPU9vxWNnfEpw2W7RtJDpsWCsBizQq95gB2QXrG5qsALV1/H7tfv4xYhTmiG5CGtcbfp4nU4yhhEqTsw==
   dependencies:
-    "@types/node" "*"
     "@types/react" "*"
+    "@types/react-native" "*"
     csstype "^2.2.0"
 
 "@types/systemjs@^0.20.6":


### PR DESCRIPTION
To solve the incompatibility issues caused by getting `@types/react-native` with the newer version of `@types/styled-components`, we are using the 4th option suggested in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015#issuecomment-488309875 as work-around.