### PR TITLE
feat(core): remove ability to provide configs via FeatureServiceRegistry

### DIFF
--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -23,7 +23,7 @@ async function simulateAsyncOperation(result: number): Promise<number> {
 }
 
 describe('defineAsyncSsrManager', () => {
-  let mockEnv: FeatureServiceEnvironment<undefined, {}>;
+  let mockEnv: FeatureServiceEnvironment<{}>;
 
   let asyncSsrManagerDefinition: FeatureServiceProviderDefinition<
     SharedAsyncSsrManager
@@ -34,10 +34,7 @@ describe('defineAsyncSsrManager', () => {
   });
 
   beforeEach(() => {
-    mockEnv = {
-      config: undefined,
-      featureServices: {'s2:logger': stubbedLogger}
-    };
+    mockEnv = {featureServices: {'s2:logger': stubbedLogger}};
   });
 
   it('creates an Async SSR Manager definition', () => {
@@ -322,7 +319,6 @@ describe('defineAsyncSsrManager', () => {
         asyncSsrManagerDefinition = defineAsyncSsrManager();
 
         asyncSsrManagerBinder = asyncSsrManagerDefinition.create({
-          config: undefined,
           featureServices: {}
         })['1.0.0'];
       });

--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -195,24 +195,6 @@ describe('createFeatureHub()', () => {
       });
     });
 
-    describe('and with Feature Service configs', () => {
-      beforeEach(() => {
-        featureHubOptions = {
-          ...featureHubOptions,
-          featureServiceConfigs: {'test:feature-service': 'mockConfig'}
-        };
-      });
-
-      it('registers and creates the Feature Services, using the relevant config', () => {
-        createFeatureHub('test:integrator', featureHubOptions);
-
-        expect(mockFeatureServiceCreate).toHaveBeenCalledWith({
-          config: 'mockConfig',
-          featureServices: {}
-        });
-      });
-    });
-
     describe('and with provided externals', () => {
       beforeEach(() => {
         featureHubOptions = {...featureHubOptions, providedExternals: {}};
@@ -284,7 +266,7 @@ describe('createFeatureHub()', () => {
 
       expectedLogCalls = [
         [
-          'The Feature Service "test:feature-service" has been successfully registered by consumer "test:integrator".'
+          'The Feature Service "test:feature-service" has been successfully registered by registrant "test:integrator".'
         ],
         ['The Feature App "test:feature-app" has been successfully created.']
       ];

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -169,7 +169,7 @@ describe('FeatureAppManager', () => {
       });
 
       expect(mockFeatureServiceRegistry.bindFeatureServices.mock.calls).toEqual(
-        [[mockFeatureAppDefinition, idSpecifier]]
+        [[mockFeatureAppDefinition, 'testId:testIdSpecifier']]
       );
 
       const {featureServices} = mockFeatureServicesBinding;
@@ -206,7 +206,7 @@ describe('FeatureAppManager', () => {
         const {featureServices} = mockFeatureServicesBinding;
 
         expect(mockBeforeCreate.mock.calls).toEqual([
-          ['testId', featureServices]
+          [mockFeatureAppDefinition.id, featureServices]
         ]);
       });
 
@@ -226,7 +226,7 @@ describe('FeatureAppManager', () => {
           const {featureServices} = mockFeatureServicesBinding;
 
           expect(mockBeforeCreate.mock.calls).toEqual([
-            ['testId', featureServices]
+            [mockFeatureAppDefinition.id, featureServices]
           ]);
         });
       });
@@ -250,7 +250,7 @@ describe('FeatureAppManager', () => {
           const {featureServices} = mockFeatureServicesBinding;
 
           expect(mockBeforeCreate.mock.calls).toEqual([
-            [`testId:${idSpecifier}`, featureServices]
+            [`${mockFeatureAppDefinition.id}:${idSpecifier}`, featureServices]
           ]);
         });
       });
@@ -411,19 +411,20 @@ describe('FeatureAppManager', () => {
       });
 
       it("registers the Feature App's own Feature Services before binding its required Feature Services", () => {
-        featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, {
-          idSpecifier: 'testIdSpecifier'
-        });
+        featureAppManager.getFeatureAppScope(mockFeatureAppDefinition);
 
         expect(
           mockFeatureServiceRegistry.registerFeatureServices.mock.calls
         ).toEqual([
-          [mockFeatureAppDefinition.ownFeatureServiceDefinitions, 'testId']
+          [
+            mockFeatureAppDefinition.ownFeatureServiceDefinitions,
+            mockFeatureAppDefinition.id
+          ]
         ]);
 
         expect(
           mockFeatureServiceRegistry.bindFeatureServices.mock.calls
-        ).toEqual([[mockFeatureAppDefinition, 'testIdSpecifier']]);
+        ).toEqual([[mockFeatureAppDefinition, mockFeatureAppDefinition.id]]);
 
         expect(featureServiceRegistryMethodCalls).toEqual([
           'registerFeatureServices',
@@ -453,7 +454,7 @@ describe('FeatureAppManager', () => {
           const {featureServices} = mockFeatureServicesBinding;
 
           expect(mockBeforeCreate.mock.calls).toEqual([
-            ['testId', featureServices]
+            [mockFeatureAppDefinition.id, featureServices]
           ]);
         });
 
@@ -480,8 +481,8 @@ describe('FeatureAppManager', () => {
             const {featureServices} = mockFeatureServicesBinding;
 
             expect(mockBeforeCreate.mock.calls).toEqual([
-              ['testId', featureServices],
-              ['testId', featureServices]
+              [mockFeatureAppDefinition.id, featureServices],
+              [mockFeatureAppDefinition.id, featureServices]
             ]);
           });
         });

--- a/packages/core/src/create-feature-hub.ts
+++ b/packages/core/src/create-feature-hub.ts
@@ -5,7 +5,6 @@ import {
   ModuleLoader
 } from './feature-app-manager';
 import {
-  FeatureServiceConfigs,
   FeatureServiceConsumerDefinition,
   FeatureServiceConsumerDependencies,
   FeatureServiceProviderDefinition,
@@ -38,12 +37,6 @@ export interface FeatureHubOptions {
    * Configurations for all Feature Apps that will potentially be created.
    */
   readonly featureAppConfigs?: FeatureAppConfigs;
-
-  /**
-   * Configurations for all Feature Services that will potentially be
-   * registered.
-   */
-  readonly featureServiceConfigs?: FeatureServiceConfigs;
 
   /**
    * Provided Feature Services. Sorting the provided definitions is not
@@ -95,7 +88,6 @@ export function createFeatureHub(
 ): FeatureHub {
   const {
     featureAppConfigs,
-    featureServiceConfigs,
     featureServiceDefinitions,
     featureServiceDependencies,
     providedExternals,
@@ -110,20 +102,18 @@ export function createFeatureHub(
   }
 
   const featureServiceRegistry = new FeatureServiceRegistry({
-    configs: featureServiceConfigs,
     externalsValidator,
     logger
   });
 
   const integratorDefinition: FeatureServiceConsumerDefinition = {
-    id: integratorId,
     dependencies: {featureServices: featureServiceDependencies}
   };
 
   if (featureServiceDefinitions) {
     featureServiceRegistry.registerFeatureServices(
       featureServiceDefinitions,
-      integratorDefinition.id
+      integratorId
     );
   }
 
@@ -135,7 +125,8 @@ export function createFeatureHub(
   });
 
   const {featureServices} = featureServiceRegistry.bindFeatureServices(
-    integratorDefinition
+    integratorDefinition,
+    integratorId
   );
 
   return {featureAppManager, featureServiceRegistry, featureServices};

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -96,7 +96,7 @@ export interface FeatureAppScopeOptions {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerId: string,
+    featureAppUid: string,
     featureServices: FeatureServices
   ) => void;
 }

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -52,6 +52,8 @@ export interface FeatureAppDefinition<
   TInstanceConfig = unknown,
   TFeatureServices extends FeatureServices = FeatureServices
 > extends FeatureServiceConsumerDefinition {
+  readonly id: string;
+
   readonly ownFeatureServiceDefinitions?: FeatureServiceProviderDefinition<
     SharedFeatureService
   >[];
@@ -94,7 +96,7 @@ export interface FeatureAppScopeOptions {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerUid: string,
+    consumerId: string,
     featureServices: FeatureServices
   ) => void;
 }
@@ -320,7 +322,7 @@ export class FeatureAppManager {
 
     const binding = this.featureServiceRegistry.bindFeatureServices(
       featureAppDefinition,
-      idSpecifier
+      featureAppUid
     );
 
     if (beforeCreate) {

--- a/packages/core/src/internal/feature-service-registry-messages.ts
+++ b/packages/core/src/internal/feature-service-registry-messages.ts
@@ -1,7 +1,7 @@
 export function featureServiceUnsupported(
   optional: boolean,
   providerId: string,
-  consumerUid: string,
+  consumerId: string,
   versionRange: string,
   supportedVersions: string[]
 ): string {
@@ -12,109 +12,109 @@ export function featureServiceUnsupported(
   )} in the unsupported version range ${JSON.stringify(
     versionRange
   )} could not be bound to consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}. The supported versions are ${JSON.stringify(supportedVersions)}.`;
 }
 
 export function featureServiceVersionInvalid(
   providerId: string,
-  consumerId: string,
+  registrantId: string,
   version: string
 ): string | undefined {
   return `The Feature Service ${JSON.stringify(
     providerId
-  )} could not be registered by consumer ${JSON.stringify(
-    consumerId
+  )} could not be registered by registrant ${JSON.stringify(
+    registrantId
   )} because it defines the invalid version ${JSON.stringify(version)}.`;
 }
 
 export function featureServiceDependencyVersionInvalid(
   optional: boolean,
   providerId: string,
-  consumerUid: string
+  consumerId: string
 ): string {
   return `The ${
     optional ? 'optional' : 'required'
   } Feature Service ${JSON.stringify(
     providerId
   )} in an invalid version could not be bound to consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}.`;
 }
 
 export function featureServiceNotRegistered(
   optional: boolean,
   providerId: string,
-  consumerUid: string
+  consumerId: string
 ): string {
   return `The ${
     optional ? 'optional' : 'required'
   } Feature Service ${JSON.stringify(
     providerId
   )} is not registered and therefore could not be bound to consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}.`;
 }
 
 export function featureServiceSuccessfullyRegistered(
   providerId: string,
-  consumerId: string
+  registrantId: string
 ): string {
   return `The Feature Service ${JSON.stringify(
     providerId
-  )} has been successfully registered by consumer ${JSON.stringify(
-    consumerId
+  )} has been successfully registered by registrant ${JSON.stringify(
+    registrantId
   )}.`;
 }
 
 export function featureServiceAlreadyRegistered(
   providerId: string,
-  consumerId: string
+  registrantId: string
 ): string {
   return `The already registered Feature Service ${JSON.stringify(
     providerId
-  )} could not be re-registered by consumer ${JSON.stringify(consumerId)}.`;
+  )} could not be re-registered by registrant ${JSON.stringify(registrantId)}.`;
 }
 
 export function featureServiceSuccessfullyBound(
   providerId: string,
-  consumerUid: string
+  consumerId: string
 ): string {
   return `The required Feature Service ${JSON.stringify(
     providerId
-  )} has been successfully bound to consumer ${JSON.stringify(consumerUid)}.`;
+  )} has been successfully bound to consumer ${JSON.stringify(consumerId)}.`;
 }
 
 export function featureServicesAlreadyBound(
-  consumerUid: string
+  consumerId: string
 ): string | undefined {
   return `All required Feature Services are already bound to consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}.`;
 }
 
 export function featureServiceCouldNotBeUnbound(
   providerId: string,
-  consumerUid: string
+  consumerId: string
 ): string {
   return `The required Feature Service ${JSON.stringify(
     providerId
-  )} could not be unbound from consumer ${JSON.stringify(consumerUid)}.`;
+  )} could not be unbound from consumer ${JSON.stringify(consumerId)}.`;
 }
 
 export function featureServiceSuccessfullyUnbound(
   providerId: string,
-  consumerUid: string
+  consumerId: string
 ): string {
   return `The required Feature Service ${JSON.stringify(
     providerId
   )} has been successfully unbound from consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}.`;
 }
 
-export function featureServicesAlreadyUnbound(consumerUid: string): string {
+export function featureServicesAlreadyUnbound(consumerId: string): string {
   return `All required Feature Services are already unbound from consumer ${JSON.stringify(
-    consumerUid
+    consumerId
   )}.`;
 }

--- a/packages/demos/src/custom-logging/app.tsx
+++ b/packages/demos/src/custom-logging/app.tsx
@@ -5,7 +5,7 @@ import featureAppDefinition from './feature-app';
 
 export interface AppProps {
   readonly beforeCreate?: (
-    consumerId: string,
+    featureAppUid: string,
     featureServices: FeatureServices
   ) => void;
 }

--- a/packages/demos/src/custom-logging/app.tsx
+++ b/packages/demos/src/custom-logging/app.tsx
@@ -5,7 +5,7 @@ import featureAppDefinition from './feature-app';
 
 export interface AppProps {
   readonly beforeCreate?: (
-    consumerUid: string,
+    consumerId: string,
     featureServices: FeatureServices
   ) => void;
 }

--- a/packages/demos/src/custom-logging/index.test.ts
+++ b/packages/demos/src/custom-logging/index.test.ts
@@ -45,13 +45,13 @@ describe('integration test: "custom logging"', () => {
     expect(messages).toContainEqual([
       '%ctest:integrator',
       'font-weight: bold',
-      'Creating Feature App with consumerUid "test:logging-app:first"...'
+      'Creating Feature App with consumerId "test:logging-app:first"...'
     ]);
 
     expect(messages).toContainEqual([
       '%ctest:integrator',
       'font-weight: bold',
-      'Creating Feature App with consumerUid "test:logging-app:second"...'
+      'Creating Feature App with consumerId "test:logging-app:second"...'
     ]);
   });
 });

--- a/packages/demos/src/custom-logging/index.test.ts
+++ b/packages/demos/src/custom-logging/index.test.ts
@@ -45,13 +45,13 @@ describe('integration test: "custom logging"', () => {
     expect(messages).toContainEqual([
       '%ctest:integrator',
       'font-weight: bold',
-      'Creating Feature App with consumerId "test:logging-app:first"...'
+      'Creating Feature App "test:logging-app:first"...'
     ]);
 
     expect(messages).toContainEqual([
       '%ctest:integrator',
       'font-weight: bold',
-      'Creating Feature App with consumerId "test:logging-app:second"...'
+      'Creating Feature App "test:logging-app:second"...'
     ]);
   });
 });

--- a/packages/demos/src/custom-logging/integrator.node.tsx
+++ b/packages/demos/src/custom-logging/integrator.node.tsx
@@ -17,7 +17,7 @@ export default async function renderApp(): Promise<AppRendererResult> {
     moduleLoader: loadCommonJsModule,
     providedExternals: {react: getPkgVersion('react')},
     featureServiceDefinitions: [
-      defineLogger(consumerUid => logger.child({consumerUid}))
+      defineLogger(consumerId => logger.child({consumerId}))
     ]
   });
 

--- a/packages/demos/src/custom-logging/integrator.tsx
+++ b/packages/demos/src/custom-logging/integrator.tsx
@@ -9,8 +9,8 @@ import {App} from './app';
 
 defineExternals({react: React});
 
-const createConsumerConsole: ConsumerLoggerCreator = consumerUid => {
-  const prefixArgs = [`%c${consumerUid}`, 'font-weight: bold'];
+const createConsumerConsole: ConsumerLoggerCreator = consumerId => {
+  const prefixArgs = [`%c${consumerId}`, 'font-weight: bold'];
 
   return {
     trace: console.trace.bind(console, ...prefixArgs),
@@ -36,10 +36,8 @@ const logger = featureServices['s2:logger'] as Logger;
 ReactDOM.hydrate(
   <FeatureHubContextProvider value={{featureAppManager}}>
     <App
-      beforeCreate={consumerUid =>
-        logger.debug(
-          `Creating Feature App with consumerUid "${consumerUid}"...`
-        )
+      beforeCreate={consumerId =>
+        logger.debug(`Creating Feature App with consumerId "${consumerId}"...`)
       }
     />
   </FeatureHubContextProvider>,

--- a/packages/demos/src/custom-logging/integrator.tsx
+++ b/packages/demos/src/custom-logging/integrator.tsx
@@ -36,8 +36,8 @@ const logger = featureServices['s2:logger'] as Logger;
 ReactDOM.hydrate(
   <FeatureHubContextProvider value={{featureAppManager}}>
     <App
-      beforeCreate={consumerId =>
-        logger.debug(`Creating Feature App with consumerId "${consumerId}"...`)
+      beforeCreate={featureAppUid =>
+        logger.debug(`Creating Feature App "${featureAppUid}"...`)
       }
     />
   </FeatureHubContextProvider>,

--- a/packages/demos/src/history-service/root-location-transformer.ts
+++ b/packages/demos/src/history-service/root-location-transformer.ts
@@ -3,19 +3,19 @@ import {createPath} from 'history';
 import {URLSearchParams} from './url-search-params';
 
 export const rootLocationTransformer: RootLocationTransformer = {
-  getConsumerPathFromRootLocation: (rootLocation, consumerUid) => {
+  getConsumerPathFromRootLocation: (rootLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
-    return searchParams.get(consumerUid) || undefined;
+    return searchParams.get(consumerId) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerUid) => {
+  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {
-      searchParams.set(consumerUid, createPath(consumerLocation));
+      searchParams.set(consumerId, createPath(consumerLocation));
     } else {
-      searchParams.delete(consumerUid);
+      searchParams.delete(consumerId);
     }
 
     const {pathname, state} = rootLocation;

--- a/packages/history-service/src/__tests__/define-history-service.node.test.ts
+++ b/packages/history-service/src/__tests__/define-history-service.node.test.ts
@@ -23,18 +23,11 @@ import {stubbedLogger} from './stubbed-logger';
 import {Writable} from './writable';
 
 describe('HistoryServiceV1 (on Node.js)', () => {
-  let mockEnv: FeatureServiceEnvironment<
-    undefined,
-    Writable<HistoryServiceDependencies>
-  >;
-
+  let mockEnv: FeatureServiceEnvironment<Writable<HistoryServiceDependencies>>;
   let createHistoryServiceBinder: () => FeatureServiceBinder<HistoryServiceV1>;
 
   beforeEach(() => {
-    mockEnv = {
-      config: undefined,
-      featureServices: {'s2:logger': stubbedLogger}
-    };
+    mockEnv = {featureServices: {'s2:logger': stubbedLogger}};
 
     createHistoryServiceBinder = () => {
       const sharedHistoryService = defineHistoryService(

--- a/packages/history-service/src/__tests__/define-history-service.test.ts
+++ b/packages/history-service/src/__tests__/define-history-service.test.ts
@@ -53,7 +53,6 @@ describe('defineHistoryService', () => {
   describe('#create', () => {
     it('creates a shared Feature Service containing version 1.0.0', () => {
       const sharedHistoryService = historyServiceDefinition.create({
-        config: undefined,
         featureServices: {}
       });
 
@@ -63,7 +62,6 @@ describe('defineHistoryService', () => {
 
   describe('HistoryServiceV1', () => {
     let mockEnv: FeatureServiceEnvironment<
-      undefined,
       Writable<HistoryServiceDependencies>
     >;
 
@@ -81,10 +79,7 @@ describe('defineHistoryService', () => {
       pushStateSpy = jest.spyOn(window.history, 'pushState');
       replaceStateSpy = jest.spyOn(window.history, 'replaceState');
 
-      mockEnv = {
-        config: undefined,
-        featureServices: {'s2:logger': stubbedLogger}
-      };
+      mockEnv = {featureServices: {'s2:logger': stubbedLogger}};
 
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(

--- a/packages/history-service/src/create-root-location-transformer.ts
+++ b/packages/history-service/src/create-root-location-transformer.ts
@@ -14,13 +14,13 @@ export interface RootLocationOptions {
 export interface RootLocationTransformer {
   getConsumerPathFromRootLocation(
     rootLocation: history.Location,
-    consumerUid: string
+    consumerId: string
   ): string | undefined;
 
   createRootLocation(
     consumerLocation: history.Location | undefined,
     currentRootLocation: history.Location,
-    consumerUid: string
+    consumerId: string
   ): history.LocationDescriptorObject;
 }
 
@@ -65,7 +65,7 @@ function createRootLocationForPrimaryConsumer(
 function createRootLocationForOtherConsumer(
   currentRootLocation: history.Location,
   consumerLocation: history.Location | undefined,
-  consumerUid: string,
+  consumerId: string,
   consumerPathsQueryParamName: string
 ): history.LocationDescriptorObject {
   const allSearchParams = createSearchParams(currentRootLocation);
@@ -74,10 +74,10 @@ function createRootLocationForOtherConsumer(
   const newConsumerPaths = consumerLocation
     ? addConsumerPath(
         consumerPaths,
-        consumerUid,
+        consumerId,
         history.createPath(consumerLocation)
       )
-    : removeConsumerPath(consumerPaths, consumerUid);
+    : removeConsumerPath(consumerPaths, consumerId);
 
   if (newConsumerPaths) {
     allSearchParams.set(consumerPathsQueryParamName, newConsumerPaths);
@@ -104,10 +104,10 @@ export function createRootLocationTransformer(
   return {
     getConsumerPathFromRootLocation: (
       rootLocation: history.Location,
-      consumerUid: string
+      consumerId: string
     ): string | undefined => {
       const {consumerPathsQueryParamName, primaryConsumerUid} = options;
-      const isPrimaryConsumer = consumerUid === primaryConsumerUid;
+      const isPrimaryConsumer = consumerId === primaryConsumerUid;
       const searchParams = createSearchParams(rootLocation);
 
       if (isPrimaryConsumer) {
@@ -125,16 +125,16 @@ export function createRootLocationTransformer(
         return undefined;
       }
 
-      return getConsumerPath(consumerPaths, consumerUid);
+      return getConsumerPath(consumerPaths, consumerId);
     },
 
     createRootLocation: (
       consumerLocation: history.Location | undefined,
       currentRootLocation: history.Location,
-      consumerUid: string
+      consumerId: string
     ): history.LocationDescriptorObject => {
       const {consumerPathsQueryParamName, primaryConsumerUid} = options;
-      const isPrimaryConsumer = consumerUid === primaryConsumerUid;
+      const isPrimaryConsumer = consumerId === primaryConsumerUid;
 
       if (isPrimaryConsumer) {
         return createRootLocationForPrimaryConsumer(
@@ -147,7 +147,7 @@ export function createRootLocationTransformer(
       return createRootLocationForOtherConsumer(
         currentRootLocation,
         consumerLocation,
-        consumerUid,
+        consumerId,
         consumerPathsQueryParamName
       );
     }

--- a/packages/history-service/src/internal/browser-consumer-history.ts
+++ b/packages/history-service/src/internal/browser-consumer-history.ts
@@ -11,10 +11,10 @@ export class BrowserConsumerHistory extends ConsumerHistory {
 
   public constructor(
     context: HistoryServiceContext,
-    consumerUid: string,
+    consumerId: string,
     historyMultiplexer: HistoryMultiplexer
   ) {
-    super(context, consumerUid, historyMultiplexer);
+    super(context, consumerId, historyMultiplexer);
 
     this.browserUnregister = historyMultiplexer.listenForPop(() => {
       this.handlePop();
@@ -24,7 +24,7 @@ export class BrowserConsumerHistory extends ConsumerHistory {
   public destroy(): void {
     this.browserUnregister();
     this.unregisterCallbacks.forEach(unregister => unregister());
-    this.historyMultiplexer.replace(this.consumerUid, undefined);
+    this.historyMultiplexer.replace(this.consumerId, undefined);
   }
 
   public listen(
@@ -65,7 +65,7 @@ export class BrowserConsumerHistory extends ConsumerHistory {
 
   private handlePop(): void {
     const location = this.historyMultiplexer.getConsumerLocation(
-      this.consumerUid
+      this.consumerId
     );
 
     if (this.matches(location)) {

--- a/packages/history-service/src/internal/consumer-history.ts
+++ b/packages/history-service/src/internal/consumer-history.ts
@@ -8,11 +8,11 @@ export abstract class ConsumerHistory implements history.History {
 
   public constructor(
     protected readonly context: HistoryServiceContext,
-    protected readonly consumerUid: string,
+    protected readonly consumerId: string,
     protected readonly historyMultiplexer: HistoryMultiplexer
   ) {
     this.location = history.createLocation(
-      historyMultiplexer.getConsumerLocation(consumerUid),
+      historyMultiplexer.getConsumerLocation(consumerId),
       undefined,
       undefined,
       history.createLocation('/')
@@ -38,7 +38,7 @@ export abstract class ConsumerHistory implements history.History {
       this.location
     );
 
-    this.historyMultiplexer.push(this.consumerUid, this.location);
+    this.historyMultiplexer.push(this.consumerId, this.location);
     this.action = 'PUSH';
   }
 
@@ -53,7 +53,7 @@ export abstract class ConsumerHistory implements history.History {
       this.location
     );
 
-    this.historyMultiplexer.replace(this.consumerUid, this.location);
+    this.historyMultiplexer.replace(this.consumerId, this.location);
     this.action = 'REPLACE';
   }
 
@@ -77,7 +77,7 @@ export abstract class ConsumerHistory implements history.History {
 
   public createHref(location: history.LocationDescriptorObject): history.Href {
     return this.historyMultiplexer.createHref(
-      this.consumerUid,
+      this.consumerId,
       history.createLocation(location, undefined, undefined, this.location)
     );
   }

--- a/packages/history-service/src/internal/consumer-paths.ts
+++ b/packages/history-service/src/internal/consumer-paths.ts
@@ -1,5 +1,5 @@
 export interface ConsumerPaths {
-  readonly [consumerUid: string]: string;
+  readonly [consumerId: string]: string;
 }
 
 function encodeConsumerPaths(consumerPaths: ConsumerPaths): string {
@@ -12,25 +12,25 @@ function decodeConsumerPaths(encodedConsumerPaths: string): ConsumerPaths {
 
 export function addConsumerPath(
   encodedConsumerPaths: string | null,
-  consumerUid: string,
+  consumerId: string,
   path: string
 ): string {
   return encodeConsumerPaths({
     ...decodeConsumerPaths(encodedConsumerPaths || '{}'),
-    [consumerUid]: path
+    [consumerId]: path
   });
 }
 
 export function removeConsumerPath(
   encodedConsumerPaths: string | null,
-  consumerUid: string
+  consumerId: string
 ): string | undefined {
   if (!encodedConsumerPaths) {
     return undefined;
   }
 
   /* istanbul ignore next */
-  const {[consumerUid]: _removed, ...rest} = decodeConsumerPaths(
+  const {[consumerId]: _removed, ...rest} = decodeConsumerPaths(
     encodedConsumerPaths
   );
 
@@ -43,7 +43,7 @@ export function removeConsumerPath(
 
 export function getConsumerPath(
   encodedConsumerPaths: string,
-  consumerUid: string
+  consumerId: string
 ): string {
-  return decodeConsumerPaths(encodedConsumerPaths)[consumerUid];
+  return decodeConsumerPaths(encodedConsumerPaths)[consumerId];
 }

--- a/packages/history-service/src/internal/create-history-service-v1-binder.ts
+++ b/packages/history-service/src/internal/create-history-service-v1-binder.ts
@@ -10,7 +10,7 @@ export function createHistoryServiceV1Binder(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers
 ): FeatureServiceBinder<HistoryServiceV1> {
-  return (consumerUid: string): FeatureServiceBinding<HistoryServiceV1> => {
+  return (consumerId: string): FeatureServiceBinding<HistoryServiceV1> => {
     let browserConsumerHistory: BrowserConsumerHistory | undefined;
     let staticConsumerHistory: history.History | undefined;
 
@@ -19,13 +19,13 @@ export function createHistoryServiceV1Binder(
         if (browserConsumerHistory) {
           context.logger.warn(
             `createBrowserHistory was called multiple times by consumer ${JSON.stringify(
-              consumerUid
+              consumerId
             )}. Returning the same history instance as before.`
           );
         } else {
           browserConsumerHistory = new BrowserConsumerHistory(
             context,
-            consumerUid,
+            consumerId,
             historyMultiplexers.browserHistoryMultiplexer
           );
         }
@@ -37,13 +37,13 @@ export function createHistoryServiceV1Binder(
         if (staticConsumerHistory) {
           context.logger.warn(
             `createStaticHistory was called multiple times by consumer ${JSON.stringify(
-              consumerUid
+              consumerId
             )}. Returning the same history instance as before.`
           );
         } else {
           staticConsumerHistory = new StaticConsumerHistory(
             context,
-            consumerUid,
+            consumerId,
             historyMultiplexers.staticHistoryMultiplexer
           );
         }

--- a/packages/history-service/src/internal/history-multiplexer.ts
+++ b/packages/history-service/src/internal/history-multiplexer.ts
@@ -2,7 +2,7 @@ import * as history from 'history';
 import {RootLocationTransformer} from '../create-root-location-transformer';
 
 export interface ConsumerHistoryStates {
-  readonly [consumerUid: string]: unknown;
+  readonly [consumerId: string]: unknown;
 }
 
 export type RootLocation = history.Location<ConsumerHistoryStates>;
@@ -31,39 +31,39 @@ export class HistoryMultiplexer {
     return this.rootHistory.location;
   }
 
-  public push(consumerUid: string, consumerLocation: history.Location): void {
+  public push(consumerId: string, consumerLocation: history.Location): void {
     this.rootHistory.push(
-      this.createRootLocation(consumerUid, consumerLocation)
+      this.createRootLocation(consumerId, consumerLocation)
     );
   }
 
   public replace(
-    consumerUid: string,
+    consumerId: string,
     consumerLocation: history.Location | undefined
   ): void {
     this.rootHistory.replace(
-      this.createRootLocation(consumerUid, consumerLocation)
+      this.createRootLocation(consumerId, consumerLocation)
     );
   }
 
   public createHref(
-    consumerUid: string,
+    consumerId: string,
     consumerLocation: history.Location
   ): history.Href {
     return this.rootHistory.createHref(
-      this.createRootLocation(consumerUid, consumerLocation)
+      this.createRootLocation(consumerId, consumerLocation)
     );
   }
 
-  public getConsumerLocation(consumerUid: string): history.Location {
+  public getConsumerLocation(consumerId: string): history.Location {
     const consumerPath =
       this.rootLocationTransformer.getConsumerPathFromRootLocation(
         this.rootHistory.location,
-        consumerUid
+        consumerId
       ) || '/';
 
     const consumerStates = this.rootHistory.location.state;
-    const consumerState = consumerStates && consumerStates[consumerUid];
+    const consumerState = consumerStates && consumerStates[consumerId];
 
     return history.createLocation(consumerPath, consumerState);
   }
@@ -77,13 +77,13 @@ export class HistoryMultiplexer {
   }
 
   private createRootLocation(
-    consumerUid: string,
+    consumerId: string,
     consumerLocation: history.Location | undefined
   ): history.Location {
     const rootLocation = this.rootLocationTransformer.createRootLocation(
       consumerLocation,
       this.rootHistory.location,
-      consumerUid
+      consumerId
     );
 
     const consumerStates = this.rootHistory.location.state;
@@ -91,7 +91,7 @@ export class HistoryMultiplexer {
 
     const newConsumerStates: ConsumerHistoryStates = {
       ...consumerStates,
-      [consumerUid]: consumerState
+      [consumerId]: consumerState
     };
 
     return history.createLocation({...rootLocation, state: newConsumerStates});

--- a/packages/history-service/src/internal/test-root-location-transformer.ts
+++ b/packages/history-service/src/internal/test-root-location-transformer.ts
@@ -3,19 +3,19 @@ import {RootLocationTransformer} from '../create-root-location-transformer';
 import {URLSearchParams} from '../internal/url-search-params';
 
 export const testRootLocationTransformer: RootLocationTransformer = {
-  getConsumerPathFromRootLocation: (rootLocation, consumerUid) => {
+  getConsumerPathFromRootLocation: (rootLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
-    return searchParams.get(consumerUid) || undefined;
+    return searchParams.get(consumerId) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerUid) => {
+  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {
-      searchParams.set(consumerUid, history.createPath(consumerLocation));
+      searchParams.set(consumerId, history.createPath(consumerLocation));
     } else {
-      searchParams.delete(consumerUid);
+      searchParams.delete(consumerId);
     }
 
     return {

--- a/packages/logger/src/__tests__/index.test.ts
+++ b/packages/logger/src/__tests__/index.test.ts
@@ -8,12 +8,12 @@ import {Stub, Stubbed, stubMethods} from 'jest-stub-methods';
 import {Logger, SharedLogger, defineLogger} from '..';
 
 describe('defineLogger', () => {
-  let mockEnv: FeatureServiceEnvironment<undefined, {}>;
+  let mockEnv: FeatureServiceEnvironment<{}>;
 
   let loggerDefinition: FeatureServiceProviderDefinition<SharedLogger>;
 
   beforeEach(() => {
-    mockEnv = {config: undefined, featureServices: {}};
+    mockEnv = {featureServices: {}};
     loggerDefinition = defineLogger();
   });
 
@@ -105,7 +105,7 @@ describe('defineLogger', () => {
           .featureService;
       });
 
-      it('calls the given createConsumerLogger with the consumerUid', () => {
+      it('calls the given createConsumerLogger with the consumerId', () => {
         expect(mockCreateConsumerLogger.mock.calls).toEqual([['test:id']]);
       });
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -11,7 +11,7 @@ export interface SharedLogger extends SharedFeatureService {
   readonly '1.0.0': FeatureServiceBinder<Logger>;
 }
 
-export type ConsumerLoggerCreator = (consumerUid: string) => Logger;
+export type ConsumerLoggerCreator = (consumerId: string) => Logger;
 
 export function defineLogger(
   createConsumerLogger: ConsumerLoggerCreator = () => console
@@ -20,8 +20,8 @@ export function defineLogger(
     id: 's2:logger',
 
     create: () => ({
-      '1.0.0': consumerUid => ({
-        featureService: createConsumerLogger(consumerUid)
+      '1.0.0': consumerId => ({
+        featureService: createConsumerLogger(consumerId)
       })
     })
   };

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -70,7 +70,7 @@ export interface FeatureAppContainerProps {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerUid: string,
+    consumerId: string,
     featureServices: FeatureServices
   ) => void;
 

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -70,7 +70,7 @@ export interface FeatureAppContainerProps {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerId: string,
+    featureAppUid: string,
     featureServices: FeatureServices
   ) => void;
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -50,7 +50,7 @@ export interface FeatureAppLoaderProps {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerId: string,
+    featureAppUid: string,
     featureServices: FeatureServices
   ) => void;
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -50,7 +50,7 @@ export interface FeatureAppLoaderProps {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    consumerUid: string,
+    consumerId: string,
     featureServices: FeatureServices
   ) => void;
 

--- a/packages/serialized-state-manager/src/__tests__/index.test.ts
+++ b/packages/serialized-state-manager/src/__tests__/index.test.ts
@@ -2,13 +2,10 @@ import {FeatureServiceEnvironment} from '@feature-hub/core';
 import {SerializedStateManagerV1, serializedStateManagerDefinition} from '..';
 
 describe('serializedStateManagerDefinition', () => {
-  let mockEnv: FeatureServiceEnvironment<undefined, {}>;
+  let mockEnv: FeatureServiceEnvironment<{}>;
 
   beforeEach(() => {
-    mockEnv = {
-      config: undefined,
-      featureServices: {}
-    };
+    mockEnv = {featureServices: {}};
   });
 
   it('defines an id', () => {

--- a/packages/serialized-state-manager/src/index.ts
+++ b/packages/serialized-state-manager/src/index.ts
@@ -68,9 +68,9 @@ export const serializedStateManagerDefinition: FeatureServiceProviderDefinition<
     const clientSideStateManager = new ClientSideStateManager();
 
     return {
-      '1.0.0': consumerUid => ({
+      '1.0.0': consumerId => ({
         featureService: new SerializedStateManager(
-          consumerUid,
+          consumerId,
           serverSideStateManager,
           clientSideStateManager
         )

--- a/packages/serialized-state-manager/src/internal/client-side-state-manager.ts
+++ b/packages/serialized-state-manager/src/internal/client-side-state-manager.ts
@@ -1,16 +1,14 @@
 export class ClientSideStateManager {
-  private serializedStatesByConsumerUid?: Record<string, string | undefined>;
+  private serializedStatesByConsumerId?: Record<string, string | undefined>;
 
   public setSerializedStates(serializedStates: string): void {
-    this.serializedStatesByConsumerUid = JSON.parse(
-      decodeURI(serializedStates)
-    );
+    this.serializedStatesByConsumerId = JSON.parse(decodeURI(serializedStates));
   }
 
-  public getSerializedState(consumerUid: string): string | undefined {
+  public getSerializedState(consumerId: string): string | undefined {
     return (
-      this.serializedStatesByConsumerUid &&
-      this.serializedStatesByConsumerUid[consumerUid]
+      this.serializedStatesByConsumerId &&
+      this.serializedStatesByConsumerId[consumerId]
     );
   }
 }

--- a/packages/serialized-state-manager/src/internal/serialized-state-manager.ts
+++ b/packages/serialized-state-manager/src/internal/serialized-state-manager.ts
@@ -4,13 +4,13 @@ import {ServerSideStateManager} from './server-side-state-manager';
 
 export class SerializedStateManager implements SerializedStateManagerV1 {
   public constructor(
-    private readonly consumerUid: string,
+    private readonly consumerId: string,
     private readonly serverSideStateManager: ServerSideStateManager,
     private readonly clientSideStateManager: ClientSideStateManager
   ) {}
 
   public register(serializeState: () => string): void {
-    this.serverSideStateManager.register(this.consumerUid, serializeState);
+    this.serverSideStateManager.register(this.consumerId, serializeState);
   }
 
   public serializeStates(): string {
@@ -22,6 +22,6 @@ export class SerializedStateManager implements SerializedStateManagerV1 {
   }
 
   public getSerializedState(): string | undefined {
-    return this.clientSideStateManager.getSerializedState(this.consumerUid);
+    return this.clientSideStateManager.getSerializedState(this.consumerId);
   }
 }

--- a/packages/serialized-state-manager/src/internal/server-side-state-manager.ts
+++ b/packages/serialized-state-manager/src/internal/server-side-state-manager.ts
@@ -1,19 +1,19 @@
 export class ServerSideStateManager {
   private readonly serializeStateCallbacks = new Map<string, () => string>();
 
-  public register(consumerUid: string, serializeState: () => string): void {
-    this.serializeStateCallbacks.set(consumerUid, serializeState);
+  public register(consumerId: string, serializeState: () => string): void {
+    this.serializeStateCallbacks.set(consumerId, serializeState);
   }
 
   public serializeStates(): string {
-    const serializedStatesByConsumerUid: Record<string, string> = {};
+    const serializedStatesByConsumerId: Record<string, string> = {};
 
     this.serializeStateCallbacks.forEach(
-      (serializeState, currentConsumerUid) => {
-        serializedStatesByConsumerUid[currentConsumerUid] = serializeState();
+      (serializeState, currentConsumerId) => {
+        serializedStatesByConsumerId[currentConsumerId] = serializeState();
       }
     );
 
-    return encodeURI(JSON.stringify(serializedStatesByConsumerUid));
+    return encodeURI(JSON.stringify(serializedStatesByConsumerId));
   }
 }

--- a/packages/server-request/src/__tests__/index.test.ts
+++ b/packages/server-request/src/__tests__/index.test.ts
@@ -6,14 +6,14 @@ import {
 import {ServerRequestV1, SharedServerRequest, defineServerRequest} from '..';
 
 describe('defineServerRequest', () => {
-  let mockEnv: FeatureServiceEnvironment<undefined, {}>;
+  let mockEnv: FeatureServiceEnvironment<{}>;
   let serverRequestDefinition: FeatureServiceProviderDefinition<
     SharedServerRequest
   >;
   let serverRequest: ServerRequestV1;
 
   beforeEach(() => {
-    mockEnv = {config: undefined, featureServices: {}};
+    mockEnv = {featureServices: {}};
 
     serverRequest = {
       url: '/app',


### PR DESCRIPTION
BREAKING CHANGE: The option `featureServiceConfigs` has been removed from the options of `createFeatureHub` and from the options of the `FeatureServiceRegistry` constructor. The `env` that is passed to a Feature Service's `create` method does not include a `config` property anymore. If a Feature Service must be configured, a factory function that accepts options, and that returns a Feature Service definition, should be used instead, see `@feature-hub/async-ssr-manager` for an example.

---

***Note:** The `primaryConsumerUid` option of the History Service will be renamed to `primaryConsumerId` in a separate PR, since this would change the API of the `@feature-hub/history-service` package, whereas this PR only changes the API of `@feature-hub/core`.*