### PR TITLE
feat(history-service): rename primaryConsumerUid to primaryConsumerId

### DIFF
--- a/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
+++ b/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
@@ -91,7 +91,7 @@ describe('#createRootLocationTransformer', () => {
       it('puts the location pathname, query params, and hash directly to the root location', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerUid: 'test:pri'
+          primaryConsumerId: 'test:pri'
         });
 
         const rootLocation = locationTransformer.createRootLocation(
@@ -110,7 +110,7 @@ describe('#createRootLocationTransformer', () => {
       it('removes undefined consumer locations from the query parameter', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerUid: 'test:pri'
+          primaryConsumerId: 'test:pri'
         });
 
         let rootLocation = locationTransformer.createRootLocation(
@@ -132,7 +132,7 @@ describe('#createRootLocationTransformer', () => {
         it('throws an error', () => {
           const locationTransformer = createRootLocationTransformer({
             consumerPathsQueryParamName: '---',
-            primaryConsumerUid: 'test:pri'
+            primaryConsumerId: 'test:pri'
           });
 
           expect(() =>
@@ -154,7 +154,7 @@ describe('#createRootLocationTransformer', () => {
       it('takes the pathname, query params, and hash of the primary consumer directly, and the pathname and query params of the other consumers encoded as a single query param, into the root location', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerUid: 'test:pri'
+          primaryConsumerId: 'test:pri'
         });
 
         let rootLocation = locationTransformer.createRootLocation(
@@ -190,7 +190,7 @@ describe('#createRootLocationTransformer', () => {
       it('returns the consumer-specific locations', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerUid: 'test:pri'
+          primaryConsumerId: 'test:pri'
         });
 
         const rootLocation = {
@@ -225,7 +225,7 @@ describe('#createRootLocationTransformer', () => {
       it('returns undefined for a non-primary consumer', () => {
         const locationTransformer = createRootLocationTransformer({
           consumerPathsQueryParamName: '---',
-          primaryConsumerUid: 'test:pri'
+          primaryConsumerId: 'test:pri'
         });
 
         const rootLocation = {

--- a/packages/history-service/src/create-root-location-transformer.ts
+++ b/packages/history-service/src/create-root-location-transformer.ts
@@ -8,7 +8,7 @@ import {URLSearchParams} from './internal/url-search-params';
 
 export interface RootLocationOptions {
   readonly consumerPathsQueryParamName: string;
-  readonly primaryConsumerUid?: string;
+  readonly primaryConsumerId?: string;
 }
 
 export interface RootLocationTransformer {
@@ -106,8 +106,8 @@ export function createRootLocationTransformer(
       rootLocation: history.Location,
       consumerId: string
     ): string | undefined => {
-      const {consumerPathsQueryParamName, primaryConsumerUid} = options;
-      const isPrimaryConsumer = consumerId === primaryConsumerUid;
+      const {consumerPathsQueryParamName, primaryConsumerId} = options;
+      const isPrimaryConsumer = consumerId === primaryConsumerId;
       const searchParams = createSearchParams(rootLocation);
 
       if (isPrimaryConsumer) {
@@ -133,8 +133,8 @@ export function createRootLocationTransformer(
       currentRootLocation: history.Location,
       consumerId: string
     ): history.LocationDescriptorObject => {
-      const {consumerPathsQueryParamName, primaryConsumerUid} = options;
-      const isPrimaryConsumer = consumerId === primaryConsumerUid;
+      const {consumerPathsQueryParamName, primaryConsumerId} = options;
+      const isPrimaryConsumer = consumerId === primaryConsumerId;
 
       if (isPrimaryConsumer) {
         return createRootLocationForPrimaryConsumer(


### PR DESCRIPTION
BREAKING CHANGE: The option `primaryConsumerUid` of `createRootLocationTransformer` has been renamed to `primaryConsumerId`.