### PR TITLE
feat(all): let featureAppId be defined by the integrator

### DIFF
--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -99,8 +99,8 @@ describe('createFeatureHub()', () => {
       );
 
       const {featureApp} = featureAppManager.getFeatureAppScope(
-        mockFeatureAppDefinition,
-        'test:feature-app'
+        'test:feature-app',
+        mockFeatureAppDefinition
       );
 
       expect(mockFeatureAppCreate).toHaveBeenCalledWith({
@@ -124,8 +124,8 @@ describe('createFeatureHub()', () => {
 
         expect(() =>
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'test:feature-app'
+            'test:feature-app',
+            mockFeatureAppDefinition
           )
         ).toThrowError(
           new Error('The external dependency "foo" is not provided.')
@@ -254,8 +254,8 @@ describe('createFeatureHub()', () => {
         });
 
         featureAppManager.getFeatureAppScope(
-          featureAppDefinition,
-          'test:feature-app'
+          'test:feature-app',
+          featureAppDefinition
         );
 
         expect(logger.info.mock.calls).toEqual(expectedLogCalls);
@@ -279,8 +279,8 @@ describe('createFeatureHub()', () => {
         });
 
         featureAppManager.getFeatureAppScope(
-          featureAppDefinition,
-          'test:feature-app'
+          'test:feature-app',
+          featureAppDefinition
         );
 
         expect(stubbedConsole.stub.info.mock.calls).toEqual(expectedLogCalls);

--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -87,7 +87,6 @@ describe('createFeatureHub()', () => {
       mockFeatureAppCreate = jest.fn(() => mockFeatureApp);
 
       mockFeatureAppDefinition = {
-        id: 'test:feature-app',
         dependencies: {externals: {foo: '^1.0.0'}},
         create: mockFeatureAppCreate
       };
@@ -100,42 +99,16 @@ describe('createFeatureHub()', () => {
       );
 
       const {featureApp} = featureAppManager.getFeatureAppScope(
-        mockFeatureAppDefinition
+        mockFeatureAppDefinition,
+        'test:feature-app'
       );
 
       expect(mockFeatureAppCreate).toHaveBeenCalledWith({
-        config: undefined,
+        featureAppId: 'test:feature-app',
         featureServices: {}
       });
 
       expect(featureApp).toBe(mockFeatureApp);
-    });
-
-    describe('with Feature App configs', () => {
-      beforeEach(() => {
-        featureHubOptions = {
-          ...featureHubOptions,
-          featureAppConfigs: {'test:feature-app': 'mockConfig'}
-        };
-      });
-
-      it('creates a Feature App, using the relevant config', () => {
-        const {featureAppManager} = createFeatureHub(
-          'test:integrator',
-          featureHubOptions
-        );
-
-        const {featureApp} = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition
-        );
-
-        expect(mockFeatureAppCreate).toHaveBeenCalledWith({
-          config: 'mockConfig',
-          featureServices: {}
-        });
-
-        expect(featureApp).toBe(mockFeatureApp);
-      });
     });
 
     describe('with provided externals', () => {
@@ -150,7 +123,10 @@ describe('createFeatureHub()', () => {
         );
 
         expect(() =>
-          featureAppManager.getFeatureAppScope(mockFeatureAppDefinition)
+          featureAppManager.getFeatureAppScope(
+            mockFeatureAppDefinition,
+            'test:feature-app'
+          )
         ).toThrowError(
           new Error('The external dependency "foo" is not provided.')
         );
@@ -190,7 +166,6 @@ describe('createFeatureHub()', () => {
       createFeatureHub('test:integrator', featureHubOptions);
 
       expect(mockFeatureServiceCreate).toHaveBeenCalledWith({
-        config: undefined,
         featureServices: {}
       });
     });
@@ -255,10 +230,7 @@ describe('createFeatureHub()', () => {
     let expectedLogCalls: string[][];
 
     beforeEach(() => {
-      featureAppDefinition = {
-        id: 'test:feature-app',
-        create: jest.fn(() => ({}))
-      };
+      featureAppDefinition = {create: jest.fn(() => ({}))};
 
       featureServiceDefinitions = [
         {id: 'test:feature-service', create: () => ({'1.0.0': jest.fn()})}
@@ -268,7 +240,9 @@ describe('createFeatureHub()', () => {
         [
           'The Feature Service "test:feature-service" has been successfully registered by registrant "test:integrator".'
         ],
-        ['The Feature App "test:feature-app" has been successfully created.']
+        [
+          'The Feature App with the ID "test:feature-app" has been successfully created.'
+        ]
       ];
     });
 
@@ -279,7 +253,10 @@ describe('createFeatureHub()', () => {
           logger
         });
 
-        featureAppManager.getFeatureAppScope(featureAppDefinition);
+        featureAppManager.getFeatureAppScope(
+          featureAppDefinition,
+          'test:feature-app'
+        );
 
         expect(logger.info.mock.calls).toEqual(expectedLogCalls);
       });
@@ -301,7 +278,10 @@ describe('createFeatureHub()', () => {
           featureServiceDefinitions
         });
 
-        featureAppManager.getFeatureAppScope(featureAppDefinition);
+        featureAppManager.getFeatureAppScope(
+          featureAppDefinition,
+          'test:feature-app'
+        );
 
         expect(stubbedConsole.stub.info.mock.calls).toEqual(expectedLogCalls);
       });

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -159,8 +159,8 @@ describe('FeatureAppManager', () => {
       });
 
       featureAppManager.getFeatureAppScope(
-        mockFeatureAppDefinition,
         featureAppId,
+        mockFeatureAppDefinition,
         {baseUrl, config}
       );
 
@@ -198,8 +198,8 @@ describe('FeatureAppManager', () => {
         });
 
         featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
           featureAppId,
+          mockFeatureAppDefinition,
           {beforeCreate: mockBeforeCreate}
         );
 
@@ -227,8 +227,8 @@ describe('FeatureAppManager', () => {
         it("doesn't throw an error", () => {
           expect(() => {
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             );
           }).not.toThrowError();
         });
@@ -266,8 +266,8 @@ describe('FeatureAppManager', () => {
         it('calls the provided ExternalsValidator with the defined externals', () => {
           try {
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             );
           } catch {}
 
@@ -279,8 +279,8 @@ describe('FeatureAppManager', () => {
         it('throws the validation error', () => {
           expect(() => {
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             );
           }).toThrowError(mockError);
         });
@@ -300,8 +300,8 @@ describe('FeatureAppManager', () => {
 
         it('calls the provided ExternalsValidator with the defined externals', () => {
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testId'
+            'testId',
+            mockFeatureAppDefinition
           );
 
           expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
@@ -312,8 +312,8 @@ describe('FeatureAppManager', () => {
         it("doesn't throw an error", () => {
           expect(() => {
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             );
           }).not.toThrowError();
         });
@@ -322,8 +322,8 @@ describe('FeatureAppManager', () => {
       describe('with a Feature App definition that declares no externals', () => {
         it('does not call the provided ExternalsValidator', () => {
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testId'
+            'testId',
+            mockFeatureAppDefinition
           );
 
           expect(mockExternalsValidator.validate).not.toHaveBeenCalled();
@@ -332,8 +332,8 @@ describe('FeatureAppManager', () => {
         it("doesn't throw an error", () => {
           expect(() => {
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             );
           }).not.toThrowError();
         });
@@ -356,8 +356,8 @@ describe('FeatureAppManager', () => {
       it('throws the same error', () => {
         expect(() =>
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testId'
+            'testId',
+            mockFeatureAppDefinition
           )
         ).toThrowError(mockError);
       });
@@ -395,8 +395,8 @@ describe('FeatureAppManager', () => {
         const featureAppId = 'testId';
 
         featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          featureAppId
+          featureAppId,
+          mockFeatureAppDefinition
         );
 
         expect(
@@ -429,14 +429,14 @@ describe('FeatureAppManager', () => {
           const mockBeforeCreate = jest.fn();
 
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
             featureAppId,
+            mockFeatureAppDefinition,
             {beforeCreate: mockBeforeCreate}
           );
 
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
             featureAppId,
+            mockFeatureAppDefinition,
             {beforeCreate: mockBeforeCreate}
           );
 
@@ -459,16 +459,16 @@ describe('FeatureAppManager', () => {
             const mockBeforeCreate = jest.fn();
 
             const featureAppScope = featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
               featureAppId,
+              mockFeatureAppDefinition,
               {beforeCreate: mockBeforeCreate}
             );
 
             featureAppScope.destroy();
 
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
               featureAppId,
+              mockFeatureAppDefinition,
               {beforeCreate: mockBeforeCreate}
             );
 
@@ -484,8 +484,8 @@ describe('FeatureAppManager', () => {
 
       it('logs an info message after creation', () => {
         featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         expect(logger.info.mock.calls).toEqual([
@@ -497,14 +497,14 @@ describe('FeatureAppManager', () => {
 
       it('returns the same Feature App scope', () => {
         const featureAppScope = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         expect(
           featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testId'
+            'testId',
+            mockFeatureAppDefinition
           )
         ).toBe(featureAppScope);
       });
@@ -512,16 +512,16 @@ describe('FeatureAppManager', () => {
       describe('when destroy() is called on the Feature App scope', () => {
         it('returns another Feature App scope', () => {
           const featureAppScope = featureAppManager.getFeatureAppScope(
-            mockFeatureAppDefinition,
-            'testId'
+            'testId',
+            mockFeatureAppDefinition
           );
 
           featureAppScope.destroy();
 
           expect(
             featureAppManager.getFeatureAppScope(
-              mockFeatureAppDefinition,
-              'testId'
+              'testId',
+              mockFeatureAppDefinition
             )
           ).not.toBe(featureAppScope);
         });
@@ -531,8 +531,8 @@ describe('FeatureAppManager', () => {
     describe('#featureApp', () => {
       it("is the Feature App that the Feature App definition's create returns", () => {
         const featureAppScope = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         expect(featureAppScope.featureApp).toBe(mockFeatureApp);
@@ -542,8 +542,8 @@ describe('FeatureAppManager', () => {
     describe('#destroy', () => {
       it('unbinds the bound Feature Services', () => {
         const featureAppScope = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         featureAppScope.destroy();
@@ -553,8 +553,8 @@ describe('FeatureAppManager', () => {
 
       it('throws an error when destroy is called multiple times', () => {
         const featureAppScope = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         featureAppScope.destroy();
@@ -568,14 +568,14 @@ describe('FeatureAppManager', () => {
 
       it('fails to destroy an already destroyed Feature App scope, even if this scope has been re-created', () => {
         const featureAppScope = featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         featureAppScope.destroy();
         featureAppManager.getFeatureAppScope(
-          mockFeatureAppDefinition,
-          'testId'
+          'testId',
+          mockFeatureAppDefinition
         );
 
         expect(() => featureAppScope.destroy()).toThrowError(
@@ -629,7 +629,7 @@ describe('FeatureAppManager', () => {
     });
 
     it('logs messages using the console', () => {
-      featureAppManager.getFeatureAppScope(mockFeatureAppDefinition, 'testId');
+      featureAppManager.getFeatureAppScope('testId', mockFeatureAppDefinition);
 
       expect(stubbedConsole.stub.info.mock.calls).toEqual([
         ['The Feature App with the ID "testId" has been successfully created.']

--- a/packages/core/src/create-feature-hub.ts
+++ b/packages/core/src/create-feature-hub.ts
@@ -1,9 +1,5 @@
 import {ExternalsValidator, ProvidedExternals} from './externals-validator';
-import {
-  FeatureAppConfigs,
-  FeatureAppManager,
-  ModuleLoader
-} from './feature-app-manager';
+import {FeatureAppManager, ModuleLoader} from './feature-app-manager';
 import {
   FeatureServiceConsumerDefinition,
   FeatureServiceConsumerDependencies,
@@ -33,11 +29,6 @@ export interface FeatureHub {
 }
 
 export interface FeatureHubOptions {
-  /**
-   * Configurations for all Feature Apps that will potentially be created.
-   */
-  readonly featureAppConfigs?: FeatureAppConfigs;
-
   /**
    * Provided Feature Services. Sorting the provided definitions is not
    * necessary, since the registry takes care of registering the given
@@ -87,7 +78,6 @@ export function createFeatureHub(
   options: FeatureHubOptions = {}
 ): FeatureHub {
   const {
-    featureAppConfigs,
     featureServiceDefinitions,
     featureServiceDependencies,
     providedExternals,
@@ -118,7 +108,6 @@ export function createFeatureHub(
   }
 
   const featureAppManager = new FeatureAppManager(featureServiceRegistry, {
-    configs: featureAppConfigs,
     externalsValidator,
     moduleLoader,
     logger

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -188,14 +188,14 @@ export class FeatureAppManager {
    * it returns the [[FeatureAppScope]] it created on the first call.
    */
   public getFeatureAppScope<TFeatureApp>(
-    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
     featureAppId: string,
+    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
     options: FeatureAppScopeOptions = {}
   ): FeatureAppScope<TFeatureApp> {
     let featureAppScope = this.featureAppScopes.get(featureAppId);
 
     if (!featureAppScope) {
-      this.registerOwnFeatureServices(featureAppDefinition, featureAppId);
+      this.registerOwnFeatureServices(featureAppId, featureAppDefinition);
 
       featureAppScope = this.createFeatureAppScope(
         featureAppDefinition,
@@ -255,8 +255,8 @@ export class FeatureAppManager {
   }
 
   private registerOwnFeatureServices(
-    featureAppDefinition: FeatureAppDefinition<unknown>,
-    featureAppId: string
+    featureAppId: string,
+    featureAppDefinition: FeatureAppDefinition<unknown>
   ): void {
     if (
       this.featureAppDefinitionsWithRegisteredOwnFeatureServices.has(

--- a/packages/core/src/internal/create-uid.ts
+++ b/packages/core/src/internal/create-uid.ts
@@ -1,3 +1,0 @@
-export function createUid(id: string, idSpecifier?: string): string {
-  return idSpecifier ? `${id}:${idSpecifier}` : id;
-}

--- a/packages/core/src/internal/is-feature-app-module.ts
+++ b/packages/core/src/internal/is-feature-app-module.ts
@@ -19,10 +19,6 @@ function isFeatureAppDefinition(
     unknown
   >;
 
-  if (typeof featureAppDefinition.id !== 'string') {
-    return false;
-  }
-
   return typeof featureAppDefinition.create === 'function';
 }
 

--- a/packages/demos/src/custom-logging/app.tsx
+++ b/packages/demos/src/custom-logging/app.tsx
@@ -5,7 +5,7 @@ import featureAppDefinition from './feature-app';
 
 export interface AppProps {
   readonly beforeCreate?: (
-    featureAppUid: string,
+    featureAppId: string,
     featureServices: FeatureServices
   ) => void;
 }
@@ -15,12 +15,12 @@ export function App({beforeCreate}: AppProps): JSX.Element {
     <>
       <FeatureAppContainer
         featureAppDefinition={featureAppDefinition}
-        idSpecifier="first"
+        featureAppId="test:logging-app:first"
         beforeCreate={beforeCreate}
       />
       <FeatureAppContainer
         featureAppDefinition={featureAppDefinition}
-        idSpecifier="second"
+        featureAppId="test:logging-app:second"
         beforeCreate={beforeCreate}
       />
     </>

--- a/packages/demos/src/custom-logging/feature-app.tsx
+++ b/packages/demos/src/custom-logging/feature-app.tsx
@@ -10,12 +10,8 @@ interface Dependencies {
 
 const featureAppDefinition: FeatureAppDefinition<
   ReactFeatureApp,
-  undefined,
-  undefined,
   Dependencies
 > = {
-  id: 'test:logging-app',
-
   dependencies: {
     externals: {react: '^16.7.0'},
     featureServices: {'s2:logger': '^1.0.0'}
@@ -33,7 +29,7 @@ const featureAppDefinition: FeatureAppDefinition<
     return {
       render: () => (
         <Card style={{margin: '20px'}}>
-          <Label>This is the {env.idSpecifier} Feature App!</Label>
+          <Label>This is the Feature App {env.featureAppId}.</Label>
         </Card>
       )
     };

--- a/packages/demos/src/custom-logging/integrator.tsx
+++ b/packages/demos/src/custom-logging/integrator.tsx
@@ -36,8 +36,8 @@ const logger = featureServices['s2:logger'] as Logger;
 ReactDOM.hydrate(
   <FeatureHubContextProvider value={{featureAppManager}}>
     <App
-      beforeCreate={featureAppUid =>
-        logger.debug(`Creating Feature App "${featureAppUid}"...`)
+      beforeCreate={featureAppId =>
+        logger.debug(`Creating Feature App "${featureAppId}"...`)
       }
     />
   </FeatureHubContextProvider>,

--- a/packages/demos/src/feature-app-in-feature-app/feature-app-inner.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/feature-app-inner.tsx
@@ -4,8 +4,6 @@ import {ReactFeatureApp} from '@feature-hub/react';
 import * as React from 'react';
 
 const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
-  id: 'test:hello-world-inner',
-
   dependencies: {
     externals: {
       react: '^16.7.0',

--- a/packages/demos/src/feature-app-in-feature-app/feature-app-outer.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/feature-app-outer.tsx
@@ -4,11 +4,7 @@ import {FeatureAppContainer, ReactFeatureApp} from '@feature-hub/react';
 import * as React from 'react';
 import innerFeatureAppDefinition from './feature-app-inner';
 
-const id = 'test:hello-world-outer';
-
 const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
-  id,
-
   dependencies: {
     externals: {
       react: '^16.7.0',
@@ -16,12 +12,12 @@ const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
     }
   },
 
-  create: ({idSpecifier}) => ({
+  create: ({featureAppId}) => ({
     render: () => (
       <Card style={{margin: '20px'}}>
         <FeatureAppContainer
           featureAppDefinition={innerFeatureAppDefinition}
-          idSpecifier={idSpecifier ? `${id}:${idSpecifier}` : id}
+          featureAppId={`${featureAppId}:test:hello-world-inner`}
         />
       </Card>
     )

--- a/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
@@ -27,6 +27,7 @@ export default async function renderApp({
   const html = ReactDOM.renderToString(
     <FeatureHubContextProvider value={{featureAppManager}}>
       <FeatureAppLoader
+        featureAppId="test:hello-world-outer"
         src="feature-app.umd.js"
         serverSrc={featureAppNodeUrl}
       />

--- a/packages/demos/src/feature-app-in-feature-app/integrator.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.tsx
@@ -22,7 +22,10 @@ const {FeatureHubContextProvider, FeatureAppLoader} = FeatureHubReact;
 
 ReactDOM.render(
   <FeatureHubContextProvider value={{featureAppManager}}>
-    <FeatureAppLoader src="feature-app.umd.js" />
+    <FeatureAppLoader
+      featureAppId="test:hello-world-outer"
+      src="feature-app.umd.js"
+    />
   </FeatureHubContextProvider>,
 
   document.querySelector('main')

--- a/packages/demos/src/history-service/app.tsx
+++ b/packages/demos/src/history-service/app.tsx
@@ -14,12 +14,12 @@ export function App({featureAppManager}: AppProps): JSX.Element {
   return (
     <FeatureHubContextProvider value={{featureAppManager}}>
       <FeatureAppContainer
+        featureAppId="test:history-consumer:a"
         featureAppDefinition={historyConsumerDefinition}
-        idSpecifier="a"
       />
       <FeatureAppContainer
+        featureAppId="test:history-consumer:b"
         featureAppDefinition={historyConsumerDefinition}
-        idSpecifier="b"
       />
     </FeatureHubContextProvider>
   );

--- a/packages/demos/src/history-service/history-consumer-definition.tsx
+++ b/packages/demos/src/history-service/history-consumer-definition.tsx
@@ -12,19 +12,15 @@ interface Dependencies {
 
 export const historyConsumerDefinition: FeatureAppDefinition<
   ReactFeatureApp,
-  undefined,
-  undefined,
   Dependencies
 > = {
-  id: 'test:history-consumer',
-
   dependencies: {
     featureServices: {
       's2:history': '^1.0.0'
     }
   },
 
-  create: ({featureServices, idSpecifier}) => {
+  create: ({featureServices, featureAppId}) => {
     const historyService = featureServices['s2:history'];
 
     const history = inBrowser
@@ -33,7 +29,7 @@ export const historyConsumerDefinition: FeatureAppDefinition<
 
     return {
       render: () => (
-        <HistoryConsumer history={history} idSpecifier={idSpecifier || ''} />
+        <HistoryConsumer history={history} consumerId={featureAppId} />
       )
     };
   }

--- a/packages/demos/src/history-service/history-consumer.tsx
+++ b/packages/demos/src/history-service/history-consumer.tsx
@@ -12,7 +12,7 @@ import Media from 'react-media';
 
 interface HistoryConsumerProps {
   readonly history: History;
-  readonly idSpecifier: string;
+  readonly consumerId: string;
 }
 
 interface HistoryConsumerState {
@@ -41,7 +41,8 @@ export class HistoryConsumer extends React.Component<
   }
 
   public render(): React.ReactNode {
-    const {idSpecifier} = this.props;
+    const {consumerId} = this.props;
+    const idSpecifier = consumerId.slice(consumerId.length - 1);
     const {pathname} = this.state;
 
     return (

--- a/packages/demos/src/integrator-dom/feature-app.ts
+++ b/packages/demos/src/integrator-dom/feature-app.ts
@@ -2,8 +2,6 @@ import {FeatureAppDefinition} from '@feature-hub/core';
 import {DomFeatureApp} from '@feature-hub/dom';
 
 const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
-  id: 'test:hello-world',
-
   create: () => ({
     attachTo(element: HTMLElement): void {
       element.replaceWith('Hello, World!');

--- a/packages/demos/src/integrator-dom/integrator.ts
+++ b/packages/demos/src/integrator-dom/integrator.ts
@@ -11,7 +11,7 @@ defineFeatureAppLoader(featureAppManager);
 const app = document.createElement('div');
 
 app.innerHTML = `
-  <feature-app-loader src="feature-app.umd.js">
+  <feature-app-loader featureAppId="test:hello-world" src="feature-app.umd.js">
     <div slot="loading">
       Loading...
     </div>

--- a/packages/demos/src/module-loader-amd/feature-app.tsx
+++ b/packages/demos/src/module-loader-amd/feature-app.tsx
@@ -4,8 +4,6 @@ import {ReactFeatureApp} from '@feature-hub/react';
 import * as React from 'react';
 
 const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
-  id: 'test:hello-world',
-
   dependencies: {
     externals: {react: '^16.7.0'}
   },

--- a/packages/demos/src/module-loader-amd/integrator.tsx
+++ b/packages/demos/src/module-loader-amd/integrator.tsx
@@ -14,7 +14,10 @@ const {featureAppManager} = createFeatureHub('test:integrator', {
 
 ReactDOM.render(
   <FeatureHubContextProvider value={{featureAppManager}}>
-    <FeatureAppLoader src="feature-app.umd.js" />
+    <FeatureAppLoader
+      featureAppId="test:hello-world"
+      src="feature-app.umd.js"
+    />
   </FeatureHubContextProvider>,
 
   document.querySelector('main')

--- a/packages/demos/src/module-loader-commonjs/feature-app.tsx
+++ b/packages/demos/src/module-loader-commonjs/feature-app.tsx
@@ -4,8 +4,6 @@ import {ReactFeatureApp} from '@feature-hub/react';
 import * as React from 'react';
 
 const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
-  id: 'test:hello-world',
-
   create(): ReactFeatureApp {
     return {
       render: () => (

--- a/packages/demos/src/module-loader-commonjs/integrator.node.tsx
+++ b/packages/demos/src/module-loader-commonjs/integrator.node.tsx
@@ -21,7 +21,11 @@ export default async function renderApp({
 
   const html = ReactDOM.renderToString(
     <FeatureHubContextProvider value={{featureAppManager}}>
-      <FeatureAppLoader src="" serverSrc={featureAppNodeUrl} />
+      <FeatureAppLoader
+        featureAppId="test:hello-world"
+        src=""
+        serverSrc={featureAppNodeUrl}
+      />
     </FeatureHubContextProvider>
   );
 

--- a/packages/demos/src/react-error-handling/feature-app.ts
+++ b/packages/demos/src/react-error-handling/feature-app.ts
@@ -2,8 +2,6 @@ import {FeatureAppDefinition} from '@feature-hub/core';
 import {ReactFeatureApp} from '@feature-hub/react';
 
 const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
-  id: 'test:invalid',
-
   // tslint:disable-next-line:no-any intentionally invalid create function
   create: () => ({} as any)
 };

--- a/packages/demos/src/react-error-handling/integrator.tsx
+++ b/packages/demos/src/react-error-handling/integrator.tsx
@@ -23,6 +23,7 @@ ReactDOM.render(
   <div style={{padding: '20px'}}>
     <FeatureHubContextProvider value={{featureAppManager}}>
       <FeatureAppLoader
+        featureAppId="test:invalid"
         src="feature-app.umd.js"
         onError={console.warn}
         renderError={error => <Error error={error} />}

--- a/packages/demos/src/server-side-rendering/app.tsx
+++ b/packages/demos/src/server-side-rendering/app.tsx
@@ -8,6 +8,7 @@ export interface AppProps {
 export function App({port}: AppProps): JSX.Element {
   return (
     <FeatureAppLoader
+      featureAppId="test:hello-world"
       src="feature-app.umd.js"
       serverSrc={port ? `http://localhost:${port}/feature-app.commonjs.js` : ''}
       css={[

--- a/packages/demos/src/server-side-rendering/feature-app.tsx
+++ b/packages/demos/src/server-side-rendering/feature-app.tsx
@@ -16,12 +16,8 @@ async function fetchSubject(): Promise<string> {
 
 const featureAppDefinition: FeatureAppDefinition<
   ReactFeatureApp,
-  undefined,
-  undefined,
   Dependencies
 > = {
-  id: 'test:hello-world',
-
   dependencies: {
     externals: {react: '^16.7.0'},
     featureServices: {'s2:serialized-state-manager': '^1.0.0'}

--- a/packages/demos/src/todomvc/footer/index.tsx
+++ b/packages/demos/src/todomvc/footer/index.tsx
@@ -10,12 +10,8 @@ export interface FooterFeatureServices {
 
 const featureAppDefinition: FeatureAppDefinition<
   ReactFeatureApp,
-  undefined,
-  undefined,
   FooterFeatureServices
 > = {
-  id: 'test:todomvc-footer',
-
   dependencies: {
     externals: {react: '^16.7.0'},
     featureServices: {'test:todomvc-todo-manager': '^1.0.0'}

--- a/packages/demos/src/todomvc/header/index.ts
+++ b/packages/demos/src/todomvc/header/index.ts
@@ -9,12 +9,8 @@ export interface HeaderFeatureServices {
 
 const featureAppDefinition: FeatureAppDefinition<
   DomFeatureApp,
-  undefined,
-  undefined,
   HeaderFeatureServices
 > = {
-  id: 'test:todomvc-header',
-
   dependencies: {
     featureServices: {'test:todomvc-todo-manager': '^1.0.0'}
   },

--- a/packages/demos/src/todomvc/integrator.tsx
+++ b/packages/demos/src/todomvc/integrator.tsx
@@ -27,12 +27,21 @@ ReactDOM.render(
   <FeatureHubContextProvider value={{featureAppManager}}>
     <section className="todoapp">
       <FeatureAppLoader
+        featureAppId="test:todomvc-header"
         baseUrl="header"
         src="feature-app-header.umd.js"
         css={[{href: 'index.css'}]}
       />
-      <FeatureAppLoader baseUrl="main" src="feature-app-main.umd.js" />
-      <FeatureAppLoader baseUrl="footer" src="feature-app-footer.umd.js" />
+      <FeatureAppLoader
+        featureAppId="s2:todomvc-main"
+        baseUrl="main"
+        src="feature-app-main.umd.js"
+      />
+      <FeatureAppLoader
+        featureAppId="test:todomvc-footer"
+        baseUrl="footer"
+        src="feature-app-footer.umd.js"
+      />
     </section>
   </FeatureHubContextProvider>,
   document.querySelector('main')

--- a/packages/demos/src/todomvc/main/index.tsx
+++ b/packages/demos/src/todomvc/main/index.tsx
@@ -10,12 +10,8 @@ export interface MainFeatureServices {
 
 const featureAppDefinition: FeatureAppDefinition<
   ReactFeatureApp,
-  undefined,
-  undefined,
   MainFeatureServices
 > = {
-  id: 's2:todomvc-main',
-
   dependencies: {
     externals: {react: '^16.7.0'},
     featureServices: {'test:todomvc-todo-manager': '^1.0.0'}

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -105,8 +105,8 @@ export function defineFeatureAppContainer(
 
       try {
         this.featureAppScope = featureAppManager.getFeatureAppScope(
-          this.featureAppDefinition,
           this.featureAppId,
+          this.featureAppDefinition,
           {baseUrl: this.baseUrl, config: this.config}
         );
 

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -29,6 +29,15 @@ export interface DomFeatureApp {
  */
 export interface FeatureAppContainerElement extends HTMLElement {
   /**
+   * The Feature App ID is used to identify the Feature App instance. Multiple
+   * Feature App Loaders with the same `featureAppId` will render the same
+   * Feature app instance. The ID is also used as a consumer ID for dependent
+   * Feature Services. To render multiple instances of the same kind of Feature
+   * App, different IDs must be used.
+   */
+  featureAppId: string;
+
+  /**
    * The absolute or relative base URL of the Feature App's assets and/or BFF.
    */
   baseUrl?: string;
@@ -39,17 +48,9 @@ export interface FeatureAppContainerElement extends HTMLElement {
   featureAppDefinition?: FeatureAppDefinition<DomFeatureApp>;
 
   /**
-   * If multiple instances of the same Feature App are placed on a single web
-   * page, an `idSpecifier` that is unique for the Feature App ID must be
-   * defined.
+   * A config object that is passed to the Feature App's `create` method.
    */
-  idSpecifier?: string;
-
-  /**
-   * A config object that is intended for the specific Feature App instance
-   * that the `feature-app-container` renders.
-   */
-  instanceConfig?: unknown;
+  config?: unknown;
 }
 
 const elementName = 'feature-app-container';
@@ -79,16 +80,16 @@ export function defineFeatureAppContainer(
   class FeatureAppContainer extends LitElement
     implements FeatureAppContainerElement {
     @property({type: String})
+    public featureAppId!: string;
+
+    @property({type: String})
     public baseUrl?: string;
 
     @property({type: Object})
     public featureAppDefinition?: FeatureAppDefinition<DomFeatureApp>;
 
-    @property({type: String})
-    public idSpecifier?: string;
-
     @property({type: Object})
-    public instanceConfig?: unknown;
+    public config?: unknown;
 
     @property({type: Object, reflect: false})
     private error?: Error;
@@ -105,11 +106,8 @@ export function defineFeatureAppContainer(
       try {
         this.featureAppScope = featureAppManager.getFeatureAppScope(
           this.featureAppDefinition,
-          {
-            baseUrl: this.baseUrl,
-            idSpecifier: this.idSpecifier,
-            instanceConfig: this.instanceConfig
-          }
+          this.featureAppId,
+          {baseUrl: this.baseUrl, config: this.config}
         );
 
         this.featureAppScope.featureApp.attachTo(this.appElement);

--- a/packages/dom/src/feature-app-loader.ts
+++ b/packages/dom/src/feature-app-loader.ts
@@ -20,6 +20,15 @@ const elementName = 'feature-app-loader';
  */
 export interface FeatureAppLoaderElement extends HTMLElement {
   /**
+   * The Feature App ID is used to identify the Feature App instance. Multiple
+   * Feature App Loaders with the same `featureAppId` will render the same
+   * Feature app instance. The ID is also used as a consumer ID for dependent
+   * Feature Services. To render multiple instances of the same kind of Feature
+   * App, different IDs must be used.
+   */
+  featureAppId: string;
+
+  /**
    * The absolute or relative base URL of the Feature App's assets and/or BFF.
    */
   baseUrl?: string;
@@ -31,17 +40,9 @@ export interface FeatureAppLoaderElement extends HTMLElement {
   src: string;
 
   /**
-   * If multiple instances of the same Feature App are placed on a single web
-   * page, an `idSpecifier` that is unique for the Feature App ID must be
-   * defined.
+   * A config object that is passed to the Feature App's `create` method.
    */
-  idSpecifier?: string;
-
-  /**
-   * A config object that is intended for the specific Feature App instance that
-   * the `feature-app-loader` loads.
-   */
-  instanceConfig?: unknown;
+  config?: unknown;
 }
 
 export interface DefineFeatureAppLoaderOptions {
@@ -70,16 +71,16 @@ export function defineFeatureAppLoader(
 
   class FeatureAppLoader extends LitElement implements FeatureAppLoaderElement {
     @property({type: String})
+    public featureAppId!: string;
+
+    @property({type: String})
     public baseUrl?: string;
 
     @property({type: String})
     public src!: string;
 
-    @property({type: String})
-    public idSpecifier?: string;
-
     @property({type: Object})
-    public instanceConfig?: unknown;
+    public config?: unknown;
 
     public render(): TemplateResult {
       return html`
@@ -104,10 +105,10 @@ export function defineFeatureAppLoader(
 
         return html`
           <feature-app-container
+            featureAppId=${this.featureAppId}
             baseUrl=${ifDefined(this.baseUrl)}
-            idSpecifier=${ifDefined(this.idSpecifier)}
             .featureAppDefinition=${definition}
-            .instanceConfig=${this.instanceConfig}
+            .config=${this.config}
           >
             <slot name="error" slot="error"></slot>
           </feature-app-container>

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -40,7 +40,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
   };
 
   beforeEach(() => {
-    mockFeatureAppDefinition = {id: 'testId', create: jest.fn()};
+    mockFeatureAppDefinition = {create: jest.fn()};
     mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
     mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
 
@@ -92,6 +92,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
         expect(() =>
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           )
@@ -120,6 +121,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
       expect(() =>
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         )
@@ -152,6 +154,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
       expect(() =>
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         )

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -122,7 +122,7 @@ describe('FeatureAppContainer', () => {
     };
 
     expect(mockGetFeatureAppScope.mock.calls).toEqual([
-      [mockFeatureAppDefinition, 'testId', expectedOptions]
+      ['testId', mockFeatureAppDefinition, expectedOptions]
     ]);
   });
 

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -47,7 +47,7 @@ describe('FeatureAppContainer', () => {
 
   beforeEach(() => {
     stubbedConsole = stubMethods(console);
-    mockFeatureAppDefinition = {id: 'testId', create: jest.fn()};
+    mockFeatureAppDefinition = {create: jest.fn()};
     mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
     mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
 
@@ -66,7 +66,10 @@ describe('FeatureAppContainer', () => {
   it('throws an error when rendered without a FeatureHubContextProvider', () => {
     expect(() =>
       TestRenderer.create(
-        <FeatureAppContainer featureAppDefinition={mockFeatureAppDefinition} />
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />
       )
     ).toThrowError(
       new Error(
@@ -99,14 +102,14 @@ describe('FeatureAppContainer', () => {
       testRendererOptions
     );
 
-  it('calls the Feature App manager with the given Feature App definition, base url, id specifier, instance config, and beforeCreate callback', () => {
+  it('calls the Feature App manager with the given featureAppDefinition, featureAppId, config, baseUrl, and beforeCreate callback', () => {
     const mockBeforeCreate = jest.fn();
 
     renderWithFeatureHubContext(
       <FeatureAppContainer
         featureAppDefinition={mockFeatureAppDefinition}
-        idSpecifier="testIdSpecifier"
-        instanceConfig="testInstanceConfig"
+        featureAppId="testId"
+        config="testConfig"
         baseUrl="/base"
         beforeCreate={mockBeforeCreate}
       />
@@ -114,13 +117,12 @@ describe('FeatureAppContainer', () => {
 
     const expectedOptions: FeatureAppScopeOptions = {
       baseUrl: '/base',
-      idSpecifier: 'testIdSpecifier',
-      instanceConfig: 'testInstanceConfig',
+      config: 'testConfig',
       beforeCreate: mockBeforeCreate
     };
 
     expect(mockGetFeatureAppScope.mock.calls).toEqual([
-      [mockFeatureAppDefinition, expectedOptions]
+      [mockFeatureAppDefinition, 'testId', expectedOptions]
     ]);
   });
 
@@ -136,7 +138,10 @@ describe('FeatureAppContainer', () => {
 
     it('renders the React element', () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppContainer featureAppDefinition={mockFeatureAppDefinition} />
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />
       );
 
       expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
@@ -166,6 +171,7 @@ describe('FeatureAppContainer', () => {
         expect(() => {
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -175,6 +181,7 @@ describe('FeatureAppContainer', () => {
       it('logs the error', () => {
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -188,6 +195,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
             />
@@ -199,6 +207,7 @@ describe('FeatureAppContainer', () => {
         it('does not log the error', () => {
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={jest.fn()}
             />
@@ -218,6 +227,7 @@ describe('FeatureAppContainer', () => {
             expect(() =>
               renderWithFeatureHubContext(
                 <FeatureAppContainer
+                  featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   onError={() => {
                     throw onErrorMockError;
@@ -235,6 +245,7 @@ describe('FeatureAppContainer', () => {
         it('renders null', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -247,6 +258,7 @@ describe('FeatureAppContainer', () => {
         it('calls the function with the error', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={() => 'Custom Error UI'}
             />
@@ -260,6 +272,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={renderError}
             />
@@ -279,6 +292,7 @@ describe('FeatureAppContainer', () => {
             expect(() =>
               renderWithFeatureHubContext(
                 <FeatureAppContainer
+                  featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   renderError={() => {
                     throw renderErrorMockError;
@@ -321,6 +335,7 @@ describe('FeatureAppContainer', () => {
         expect(() => {
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -332,6 +347,7 @@ describe('FeatureAppContainer', () => {
       it('logs the error', () => {
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -346,6 +362,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
             />
@@ -358,6 +375,7 @@ describe('FeatureAppContainer', () => {
         it('does not log the error', () => {
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={jest.fn()}
             />
@@ -378,6 +396,7 @@ describe('FeatureAppContainer', () => {
             expect(() =>
               renderWithFeatureHubContext(
                 <FeatureAppContainer
+                  featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   onError={() => {
                     throw onErrorMockError;
@@ -399,6 +418,7 @@ describe('FeatureAppContainer', () => {
         it('renders null', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -412,6 +432,7 @@ describe('FeatureAppContainer', () => {
         it('calls the function with the error', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={() => 'Custom Error UI'}
             />
@@ -426,6 +447,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={renderError}
             />
@@ -441,6 +463,7 @@ describe('FeatureAppContainer', () => {
       it('calls destroy() on the Feature App scope', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -466,6 +489,7 @@ describe('FeatureAppContainer', () => {
         it('logs the error', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -481,6 +505,7 @@ describe('FeatureAppContainer', () => {
 
             const testRenderer = renderWithFeatureHubContext(
               <FeatureAppContainer
+                featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={onError}
               />
@@ -494,6 +519,7 @@ describe('FeatureAppContainer', () => {
           it('does not log the error', () => {
             const testRenderer = renderWithFeatureHubContext(
               <FeatureAppContainer
+                featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={jest.fn()}
               />
@@ -514,6 +540,7 @@ describe('FeatureAppContainer', () => {
             it('re-throws the error', () => {
               const testRenderer = renderWithFeatureHubContext(
                 <FeatureAppContainer
+                  featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   onError={() => {
                     throw onErrorMockError;
@@ -552,7 +579,10 @@ describe('FeatureAppContainer', () => {
       const mockSetInnerHtml = jest.fn();
 
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppContainer featureAppDefinition={mockFeatureAppDefinition} />,
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />,
         {
           testRendererOptions: {
             createNodeMock: () => ({
@@ -591,6 +621,7 @@ describe('FeatureAppContainer', () => {
         expect(() =>
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />,
             {testRendererOptions: {createNodeMock: () => ({})}}
@@ -601,6 +632,7 @@ describe('FeatureAppContainer', () => {
       it('logs the error', () => {
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />,
           {testRendererOptions: {createNodeMock: () => ({})}}
@@ -615,6 +647,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
             />,
@@ -635,6 +668,7 @@ describe('FeatureAppContainer', () => {
             expect(() =>
               renderWithFeatureHubContext(
                 <FeatureAppContainer
+                  featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   onError={() => {
                     throw onErrorMockError;
@@ -658,6 +692,7 @@ describe('FeatureAppContainer', () => {
 
           renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={renderError}
             />,
@@ -672,6 +707,7 @@ describe('FeatureAppContainer', () => {
 
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               renderError={() => customErrorUI}
             />,
@@ -686,6 +722,7 @@ describe('FeatureAppContainer', () => {
         it('renders null', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />,
             {testRendererOptions: {createNodeMock: () => ({})}}
@@ -700,6 +737,7 @@ describe('FeatureAppContainer', () => {
       it('calls destroy() on the Feature App scope', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -725,6 +763,7 @@ describe('FeatureAppContainer', () => {
         it('logs the error', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
+              featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />
           );
@@ -740,6 +779,7 @@ describe('FeatureAppContainer', () => {
 
             const testRenderer = renderWithFeatureHubContext(
               <FeatureAppContainer
+                featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={onError}
               />
@@ -774,6 +814,7 @@ describe('FeatureAppContainer', () => {
       it('renders nothing and logs an error', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -802,7 +843,10 @@ describe('FeatureAppContainer', () => {
 
     it('logs the creation error', () => {
       renderWithFeatureHubContext(
-        <FeatureAppContainer featureAppDefinition={mockFeatureAppDefinition} />
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />
       );
 
       expect(logger.error.mock.calls).toEqual([[mockError]]);
@@ -814,6 +858,7 @@ describe('FeatureAppContainer', () => {
 
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
             onError={onError}
           />
@@ -833,6 +878,7 @@ describe('FeatureAppContainer', () => {
           expect(() =>
             renderWithFeatureHubContext(
               <FeatureAppContainer
+                featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={() => {
                   throw onErrorMockError;
@@ -852,6 +898,7 @@ describe('FeatureAppContainer', () => {
 
         renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
             renderError={renderError}
           />
@@ -865,6 +912,7 @@ describe('FeatureAppContainer', () => {
 
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
             renderError={() => customErrorUI}
           />
@@ -884,6 +932,7 @@ describe('FeatureAppContainer', () => {
           expect(() =>
             renderWithFeatureHubContext(
               <FeatureAppContainer
+                featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 renderError={() => {
                   throw renderErrorMockError;
@@ -901,6 +950,7 @@ describe('FeatureAppContainer', () => {
       it('renders null', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -913,6 +963,7 @@ describe('FeatureAppContainer', () => {
       it('does nothing', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
+            featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />
         );
@@ -936,7 +987,10 @@ describe('FeatureAppContainer', () => {
       };
 
       renderWithFeatureHubContext(
-        <FeatureAppContainer featureAppDefinition={mockFeatureAppDefinition} />,
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />,
         {customLogger: false}
       );
 

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -78,19 +78,25 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
   describe('without a serverSrc', () => {
     it('does not try to load a Feature App definition', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockGetAsyncFeatureAppDefinition).not.toHaveBeenCalled();
     });
 
     it('does not schedule a rerender on the Async SSR Manager', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
     });
 
     it('does not add a URL for hydration', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
     });
@@ -99,7 +105,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
   describe('with a serverSrc', () => {
     it('loads a Feature App definition for the serverSrc', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -111,6 +121,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       it('loads a Feature App definition for the prepended serverSrc', () => {
         renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             baseUrl="http://example.com"
             src="example.js"
             serverSrc="example-node.js"
@@ -125,7 +136,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
     it('schedules a rerender on the Async SSR Manager with the feature app definition promise', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAsyncSsrManager.scheduleRerender.mock.calls).toEqual([
@@ -135,7 +150,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
     it('adds the src URL for hydration', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAddUrlForHydration).toHaveBeenCalledWith('example.js');
@@ -145,6 +164,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       it('adds the prepended src URL for hydration', () => {
         renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             baseUrl="http://example.com"
             src="example.js"
             serverSrc="example-node.js"
@@ -161,10 +181,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
 
       beforeEach(() => {
-        mockFeatureAppDefinition = {
-          id: 'testId',
-          create: jest.fn()
-        };
+        mockFeatureAppDefinition = {create: jest.fn()};
 
         mockAsyncFeatureAppDefinition = new AsyncValue(
           Promise.resolve(mockFeatureAppDefinition)
@@ -173,7 +190,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
       it('does not schedule a rerender on the Async SSR Manager', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            serverSrc="example-node.js"
+          />
         );
 
         expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -194,14 +215,14 @@ describe('FeatureAppLoader (on Node.js)', () => {
             <FeatureAppLoader
               src="example.js"
               serverSrc="example-node.js"
-              idSpecifier="testIdSpecifier"
+              featureAppId="testId"
             />
           )
         ).toThrowError(mockError);
 
         expect(stubbedConsole.stub.error.mock.calls).toEqual([
           [
-            'The Feature App for the src "example-node.js" and the ID specifier "testIdSpecifier" could not be rendered.',
+            'The Feature App for the src "example-node.js" and the ID "testId" could not be rendered.',
             mockError
           ]
         ]);
@@ -210,7 +231,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
       it('does not schedule a rerender on the Async SSR Manager', () => {
         try {
           renderWithFeatureHubContext(
-            <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+            <FeatureAppLoader
+              featureAppId="testId"
+              src="example.js"
+              serverSrc="example-node.js"
+            />
           );
         } catch {}
 
@@ -220,7 +245,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
       it('adds the src URL for hydration', () => {
         try {
           renderWithFeatureHubContext(
-            <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+            <FeatureAppLoader
+              featureAppId="testId"
+              src="example.js"
+              serverSrc="example-node.js"
+            />
           );
         } catch {}
 
@@ -232,7 +261,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
   describe('without a css prop', () => {
     it('does not try to add stylesheets for SSR', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
@@ -243,6 +276,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
     it('adds the stylesheets for SSR', () => {
       renderWithFeatureHubContext(
         <FeatureAppLoader
+          featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
           css={[{href: 'foo.css'}]}
@@ -258,6 +292,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       it('adds the stylesheets for SSR', () => {
         renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             baseUrl="http://feature-hub.io"
             src="example.js"
             serverSrc="example-node.js"

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -94,7 +94,9 @@ describe('FeatureAppLoader', () => {
 
   it('throws an error when rendered without a FeatureHubContextProvider', () => {
     expect(() =>
-      TestRenderer.create(<FeatureAppLoader src="example.js" />)
+      TestRenderer.create(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      )
     ).toThrowError(
       new Error(
         'No Feature Hub context was provided! There are two possible causes: 1.) No FeatureHubContextProvider was rendered in the React tree. 2.) A Feature App that renders itself a FeatureAppLoader or a FeatureAppContainer did not declare @feature-hub/react as an external package.'
@@ -129,7 +131,7 @@ describe('FeatureAppLoader', () => {
     const handleError = jest.fn();
 
     const testRenderer = renderWithFeatureHubContext(
-      <FeatureAppLoader src="" />,
+      <FeatureAppLoader featureAppId="testId" src="" />,
       {handleError}
     );
 
@@ -140,7 +142,7 @@ describe('FeatureAppLoader', () => {
 
   it('initially renders nothing', () => {
     const testRenderer = renderWithFeatureHubContext(
-      <FeatureAppLoader src="example.js" />
+      <FeatureAppLoader featureAppId="testId" src="example.js" />
     );
 
     expect(testRenderer.toJSON()).toBeNull();
@@ -148,13 +150,17 @@ describe('FeatureAppLoader', () => {
 
   describe('without a css prop', () => {
     it('does not change the document head', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(document.head).toMatchSnapshot();
     });
 
     it('does not try to add stylesheets for SSR', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
     });
@@ -164,6 +170,7 @@ describe('FeatureAppLoader', () => {
     it('appends link elements to the document head', () => {
       renderWithFeatureHubContext(
         <FeatureAppLoader
+          featureAppId="testId"
           src="example.js"
           css={[
             {href: 'https://example.com/foo.css'},
@@ -177,7 +184,11 @@ describe('FeatureAppLoader', () => {
 
     it('does not add the stylesheets for SSR', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" css={[{href: 'foo.css'}]} />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          css={[{href: 'foo.css'}]}
+        />
       );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
@@ -186,11 +197,19 @@ describe('FeatureAppLoader', () => {
     describe('when the css has already been appended', () => {
       it('does not append the css a second time', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" css={[{href: 'foo.css'}]} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            css={[{href: 'foo.css'}]}
+          />
         );
 
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" css={[{href: 'foo.css'}]} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            css={[{href: 'foo.css'}]}
+          />
         );
 
         expect(document.head).toMatchSnapshot();
@@ -201,6 +220,7 @@ describe('FeatureAppLoader', () => {
       it('appends link elements to the document head', () => {
         renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             baseUrl="http://feature-hub.io"
             src="example.js"
             css={[
@@ -219,10 +239,7 @@ describe('FeatureAppLoader', () => {
     let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
 
     beforeEach(() => {
-      mockFeatureAppDefinition = {
-        id: 'testId',
-        create: jest.fn()
-      };
+      mockFeatureAppDefinition = {create: jest.fn()};
 
       mockAsyncFeatureAppDefinition = new AsyncValue(
         Promise.resolve(mockFeatureAppDefinition)
@@ -230,7 +247,9 @@ describe('FeatureAppLoader', () => {
     });
 
     it('calls getAsyncFeatureAppDefinition with the given src exactly once', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
         ['example.js']
@@ -240,7 +259,11 @@ describe('FeatureAppLoader', () => {
     describe('with a baseUrl and a relative src', () => {
       it('calls getAsyncFeatureAppDefinition with a prepended src', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader baseUrl="/base" src="example.js" />
+          <FeatureAppLoader
+            featureAppId="testId"
+            baseUrl="/base"
+            src="example.js"
+          />
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -252,7 +275,11 @@ describe('FeatureAppLoader', () => {
     describe('with a baseUrl and an absolute src', () => {
       it('calls getAsyncFeatureAppDefinition with the absolute src', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader baseUrl="/base" src="http://example.com/foo.js" />
+          <FeatureAppLoader
+            featureAppId="testId"
+            baseUrl="/base"
+            src="http://example.com/foo.js"
+          />
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -269,8 +296,8 @@ describe('FeatureAppLoader', () => {
       const testRenderer = renderWithFeatureHubContext(
         <FeatureAppLoader
           src="example.js"
-          idSpecifier="testIdSpecifier"
-          instanceConfig="testInstanceConfig"
+          featureAppId="testId"
+          config="testConfig"
           beforeCreate={beforeCreate}
           onError={onError}
           renderError={renderError}
@@ -281,13 +308,13 @@ describe('FeatureAppLoader', () => {
       expect(testRenderer.toJSON()).toBe('mocked FeatureAppContainer');
 
       const expectedProps = {
-        featureAppDefinition: mockFeatureAppDefinition,
-        idSpecifier: 'testIdSpecifier',
-        instanceConfig: 'testInstanceConfig',
+        baseUrl: '/base',
         beforeCreate,
+        config: 'testConfig',
+        featureAppDefinition: mockFeatureAppDefinition,
+        featureAppId: 'testId',
         onError,
-        renderError,
-        baseUrl: '/base'
+        renderError
       };
 
       expect(FeatureAppContainer).toHaveBeenCalledWith(expectedProps, {});
@@ -295,7 +322,11 @@ describe('FeatureAppLoader', () => {
 
     it('does not schedule a rerender on the Async SSR Manager', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -303,7 +334,11 @@ describe('FeatureAppLoader', () => {
 
     it('does not add a URL for hydration', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
@@ -325,7 +360,7 @@ describe('FeatureAppLoader', () => {
 
     it('renders nothing and logs an error (only once)', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" idSpecifier="testIdSpecifier" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />
       );
 
       try {
@@ -337,7 +372,7 @@ describe('FeatureAppLoader', () => {
 
         expect(logger.error.mock.calls).toEqual([
           [
-            'The Feature App for the src "example.js" and the ID specifier "testIdSpecifier" could not be rendered.',
+            'The Feature App for the src "example.js" and the ID "testId" could not be rendered.',
             mockError
           ]
         ]);
@@ -349,7 +384,11 @@ describe('FeatureAppLoader', () => {
         const onError = jest.fn();
 
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" onError={onError} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            onError={onError}
+          />
         );
 
         expect(onError.mock.calls).toEqual([[mockError]]);
@@ -357,7 +396,11 @@ describe('FeatureAppLoader', () => {
 
       it('does not log the error', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" onError={jest.fn()} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            onError={jest.fn()}
+          />
         );
 
         expect(logger.error).not.toHaveBeenCalled();
@@ -375,6 +418,7 @@ describe('FeatureAppLoader', () => {
 
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppLoader
+              featureAppId="testId"
               src="example.js"
               onError={() => {
                 throw onErrorMockError;
@@ -395,7 +439,11 @@ describe('FeatureAppLoader', () => {
         const renderError = jest.fn().mockReturnValue(null);
 
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" renderError={renderError} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            renderError={renderError}
+          />
         );
 
         expect(renderError.mock.calls).toEqual([[mockError]]);
@@ -404,6 +452,7 @@ describe('FeatureAppLoader', () => {
       it('renders what the function returns', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             src="example.js"
             renderError={() => 'Custom Error UI'}
           />
@@ -424,6 +473,7 @@ describe('FeatureAppLoader', () => {
 
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppLoader
+              featureAppId="testId"
               src="example.js"
               renderError={() => {
                 throw renderErrorMockError;
@@ -442,6 +492,7 @@ describe('FeatureAppLoader', () => {
         it('renders what the renderError function returns', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppLoader
+              featureAppId="testId"
               src="example.js"
               onError={jest.fn()}
               renderError={() => 'Custom Error UI'}
@@ -464,6 +515,7 @@ describe('FeatureAppLoader', () => {
 
             const testRenderer = renderWithFeatureHubContext(
               <FeatureAppLoader
+                featureAppId="testId"
                 src="example.js"
                 onError={() => {
                   throw onErrorMockError;
@@ -487,10 +539,7 @@ describe('FeatureAppLoader', () => {
     let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
 
     beforeEach(() => {
-      mockFeatureAppDefinition = {
-        id: 'testId',
-        create: jest.fn()
-      };
+      mockFeatureAppDefinition = {create: jest.fn()};
 
       mockAsyncFeatureAppDefinition = new AsyncValue(
         new Promise<FeatureAppDefinition<unknown>>(resolve =>
@@ -501,7 +550,9 @@ describe('FeatureAppLoader', () => {
     });
 
     it('calls getAsyncFeatureAppDefinition with the given src exactly twice', () => {
-      renderWithFeatureHubContext(<FeatureAppLoader src="example.js" />);
+      renderWithFeatureHubContext(
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
+      );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
         ['example.js'],
@@ -512,7 +563,11 @@ describe('FeatureAppLoader', () => {
     describe('with a baseUrl and a relative src', () => {
       it('calls getAsyncFeatureAppDefinition with a prepended src', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader baseUrl="/base" src="example.js" />
+          <FeatureAppLoader
+            featureAppId="testId"
+            baseUrl="/base"
+            src="example.js"
+          />
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -525,7 +580,11 @@ describe('FeatureAppLoader', () => {
     describe('with a baseUrl and an absolute src', () => {
       it('calls getAsyncFeatureAppDefinition with the absolute src', () => {
         renderWithFeatureHubContext(
-          <FeatureAppLoader baseUrl="/base" src="http://example.com/foo.js" />
+          <FeatureAppLoader
+            featureAppId="testId"
+            baseUrl="/base"
+            src="http://example.com/foo.js"
+          />
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -537,7 +596,7 @@ describe('FeatureAppLoader', () => {
 
     it('initially renders nothing', () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />
       );
 
       expect(testRenderer.toJSON()).toBeNull();
@@ -545,7 +604,7 @@ describe('FeatureAppLoader', () => {
 
     it('renders a FeatureAppContainer when loaded', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" idSpecifier="testIdSpecifier" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />
       );
 
       await mockAsyncFeatureAppDefinition.promise;
@@ -555,7 +614,11 @@ describe('FeatureAppLoader', () => {
 
     it('does not schedule a rerender on the Async SSR Manager', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -563,7 +626,11 @@ describe('FeatureAppLoader', () => {
 
     it('does not add a URL for hydration', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" serverSrc="example-node.js" />
+        <FeatureAppLoader
+          featureAppId="testId"
+          src="example.js"
+          serverSrc="example-node.js"
+        />
       );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
@@ -572,7 +639,7 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('renders nothing', async () => {
         const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" />
+          <FeatureAppLoader featureAppId="testId" src="example.js" />
         );
 
         testRenderer.unmount();
@@ -600,7 +667,7 @@ describe('FeatureAppLoader', () => {
 
     it('renders nothing and logs an error', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" idSpecifier="testIdSpecifier" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />
       );
 
       expect.assertions(4); // Note: one of the assertions is in afterEach.
@@ -615,7 +682,7 @@ describe('FeatureAppLoader', () => {
 
       expect(logger.error.mock.calls).toEqual([
         [
-          'The Feature App for the src "example.js" and the ID specifier "testIdSpecifier" could not be rendered.',
+          'The Feature App for the src "example.js" and the ID "testId" could not be rendered.',
           mockError
         ]
       ]);
@@ -627,7 +694,11 @@ describe('FeatureAppLoader', () => {
 
         try {
           renderWithFeatureHubContext(
-            <FeatureAppLoader src="example.js" onError={onError} />
+            <FeatureAppLoader
+              featureAppId="testId"
+              src="example.js"
+              onError={onError}
+            />
           );
 
           await mockAsyncFeatureAppDefinition.promise;
@@ -639,7 +710,11 @@ describe('FeatureAppLoader', () => {
       it('does not log the error', async () => {
         try {
           renderWithFeatureHubContext(
-            <FeatureAppLoader src="example.js" onError={jest.fn()} />
+            <FeatureAppLoader
+              featureAppId="testId"
+              src="example.js"
+              onError={jest.fn()}
+            />
           );
 
           await mockAsyncFeatureAppDefinition.promise;
@@ -660,6 +735,7 @@ describe('FeatureAppLoader', () => {
 
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppLoader
+              featureAppId="testId"
               src="example.js"
               onError={() => {
                 throw onErrorMockError;
@@ -684,7 +760,11 @@ describe('FeatureAppLoader', () => {
             });
 
             const testRenderer = renderWithFeatureHubContext(
-              <FeatureAppLoader src="example.js" onError={onError} />
+              <FeatureAppLoader
+                featureAppId="testId"
+                src="example.js"
+                onError={onError}
+              />
             );
 
             testRenderer.unmount();
@@ -699,6 +779,7 @@ describe('FeatureAppLoader', () => {
           it('renders nothing', async () => {
             const testRenderer = renderWithFeatureHubContext(
               <FeatureAppLoader
+                featureAppId="testId"
                 src="example.js"
                 onError={() => {
                   throw onErrorMockError;
@@ -723,7 +804,11 @@ describe('FeatureAppLoader', () => {
         const renderError = jest.fn().mockReturnValue(null);
 
         renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" renderError={renderError} />
+          <FeatureAppLoader
+            featureAppId="testId"
+            src="example.js"
+            renderError={renderError}
+          />
         );
 
         try {
@@ -736,6 +821,7 @@ describe('FeatureAppLoader', () => {
       it('renders what the function returns', async () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppLoader
+            featureAppId="testId"
             src="example.js"
             renderError={() => 'Custom Error UI'}
           />
@@ -760,6 +846,7 @@ describe('FeatureAppLoader', () => {
 
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppLoader
+              featureAppId="testId"
               src="example.js"
               renderError={() => {
                 throw renderErrorMockError;
@@ -782,7 +869,7 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('logs an error', async () => {
         const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader src="example.js" />
+          <FeatureAppLoader featureAppId="testId" src="example.js" />
         );
 
         testRenderer.unmount();
@@ -797,7 +884,7 @@ describe('FeatureAppLoader', () => {
 
         expect(logger.error.mock.calls).toEqual([
           [
-            'The Feature App for the src "example.js" could not be rendered.',
+            'The Feature App for the src "example.js" and the ID "testId" could not be rendered.',
             mockError
           ]
         ]);
@@ -816,13 +903,13 @@ describe('FeatureAppLoader', () => {
       );
 
       renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" idSpecifier="testIdSpecifier" />,
+        <FeatureAppLoader src="example.js" featureAppId="testId" />,
         {customLogger: false}
       );
 
       expectConsoleErrorCalls([
         [
-          'The Feature App for the src "example.js" and the ID specifier "testIdSpecifier" could not be rendered.',
+          'The Feature App for the src "example.js" and the ID "testId" could not be rendered.',
           mockError
         ]
       ]);

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -44,6 +44,15 @@ export type FeatureApp = ReactFeatureApp | DomFeatureApp;
 
 export interface FeatureAppContainerProps {
   /**
+   * The Feature App ID is used to identify the Feature App instance. Multiple
+   * Feature App Loaders with the same `featureAppId` will render the same
+   * Feature app instance. The ID is also used as a consumer ID for dependent
+   * Feature Services. To render multiple instances of the same kind of Feature
+   * App, different IDs must be used.
+   */
+  readonly featureAppId: string;
+
+  /**
    * The absolute or relative base URL of the Feature App's assets and/or BFF.
    */
   readonly baseUrl?: string;
@@ -54,23 +63,15 @@ export interface FeatureAppContainerProps {
   readonly featureAppDefinition: FeatureAppDefinition<unknown>;
 
   /**
-   * If multiple instances of the same Feature App are placed on a single web
-   * page, an `idSpecifier` that is unique for the Feature App ID must be
-   * defined.
+   * A config object that is passed to the Feature App's `create` method.
    */
-  readonly idSpecifier?: string;
-
-  /**
-   * A config object that is intended for the specific Feature App instance that
-   * the `FeatureAppContainer` renders.
-   */
-  readonly instanceConfig?: unknown;
+  readonly config?: unknown;
 
   /**
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    featureAppUid: string,
+    featureAppId: string,
     featureServices: FeatureServices
   ) => void;
 
@@ -104,16 +105,17 @@ class InternalFeatureAppContainer extends React.PureComponent<
     const {
       baseUrl,
       beforeCreate,
-      featureAppManager,
+      config,
       featureAppDefinition,
-      idSpecifier,
-      instanceConfig
+      featureAppId,
+      featureAppManager
     } = props;
 
     try {
       this.featureAppScope = featureAppManager.getFeatureAppScope(
         featureAppDefinition,
-        {baseUrl, idSpecifier, instanceConfig, beforeCreate}
+        featureAppId,
+        {baseUrl, config, beforeCreate}
       );
 
       if (!isFeatureApp(this.featureAppScope.featureApp)) {

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -113,8 +113,8 @@ class InternalFeatureAppContainer extends React.PureComponent<
 
     try {
       this.featureAppScope = featureAppManager.getFeatureAppScope(
-        featureAppDefinition,
         featureAppId,
+        featureAppDefinition,
         {baseUrl, config, beforeCreate}
       );
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -10,6 +10,15 @@ import {prependBaseUrl} from './internal/prepend-base-url';
 
 export interface FeatureAppLoaderProps {
   /**
+   * The Feature App ID is used to identify the Feature App instance. Multiple
+   * Feature App Loaders with the same `featureAppId` will render the same
+   * Feature app instance. The ID is also used as a consumer ID for dependent
+   * Feature Services. To render multiple instances of the same kind of Feature
+   * App, different IDs must be used.
+   */
+  readonly featureAppId: string;
+
+  /**
    * The absolute or relative base URL of the Feature App's assets and/or BFF.
    */
   readonly baseUrl?: string;
@@ -34,23 +43,15 @@ export interface FeatureAppLoaderProps {
   readonly css?: Css[];
 
   /**
-   * If multiple instances of the same Feature App are placed on a single web
-   * page, an `idSpecifier` that is unique for the Feature App ID must be
-   * defined.
+   * A config object that is passed to the Feature App's `create` method.
    */
-  readonly idSpecifier?: string;
-
-  /**
-   * A config object that is intended for the specific Feature App instance that
-   * the `FeatureAppLoader` loads and renders.
-   */
-  readonly instanceConfig?: unknown;
+  readonly config?: unknown;
 
   /**
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    featureAppUid: string,
+    featureAppId: string,
     featureServices: FeatureServices
   ) => void;
 
@@ -168,8 +169,8 @@ class InternalFeatureAppLoader extends React.PureComponent<
     const {
       baseUrl,
       beforeCreate,
-      idSpecifier,
-      instanceConfig,
+      config,
+      featureAppId,
       onError,
       renderError
     } = this.props;
@@ -192,10 +193,10 @@ class InternalFeatureAppLoader extends React.PureComponent<
     return (
       <FeatureAppContainer
         baseUrl={baseUrl}
-        featureAppDefinition={featureAppDefinition}
-        idSpecifier={idSpecifier}
-        instanceConfig={instanceConfig}
         beforeCreate={beforeCreate}
+        config={config}
+        featureAppDefinition={featureAppDefinition}
+        featureAppId={featureAppId}
         onError={onError}
         renderError={renderError}
       />
@@ -274,7 +275,7 @@ class InternalFeatureAppLoader extends React.PureComponent<
   private logError(error: Error): void {
     const {
       baseUrl,
-      idSpecifier,
+      featureAppId,
       logger,
       src: clientSrc,
       serverSrc
@@ -283,15 +284,9 @@ class InternalFeatureAppLoader extends React.PureComponent<
     const src = inBrowser ? clientSrc : serverSrc;
 
     logger.error(
-      idSpecifier
-        ? `The Feature App for the src ${JSON.stringify(
-            src && prependBaseUrl(baseUrl, src)
-          )} and the ID specifier ${JSON.stringify(
-            idSpecifier
-          )} could not be rendered.`
-        : `The Feature App for the src ${JSON.stringify(
-            src
-          )} could not be rendered.`,
+      `The Feature App for the src ${JSON.stringify(
+        src && prependBaseUrl(baseUrl, src)
+      )} and the ID ${JSON.stringify(featureAppId)} could not be rendered.`,
       error
     );
   }

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -195,8 +195,8 @@ class InternalFeatureAppLoader extends React.PureComponent<
         baseUrl={baseUrl}
         beforeCreate={beforeCreate}
         config={config}
-        featureAppDefinition={featureAppDefinition}
         featureAppId={featureAppId}
+        featureAppDefinition={featureAppDefinition}
         onError={onError}
         renderError={renderError}
       />


### PR DESCRIPTION
fixes #495

BREAKING CHANGE: The option `featureAppConfigs` has been removed from the options of `createFeatureHub` and from the options of the `FeatureAppManager` constructor. The `env` that is passed to a Feature App's `create` method does not include a `config` property anymore. If a Feature App must be configured, the integrator needs to specify the `config` prop of the `FeatureAppLoader` or `FeatureAppContainer`. Furthermore, the `FeatureAppLoader` or `FeatureAppContainer` now require a `featureAppId` prop, and the `instanceConfig` and `idSpecifier` props have been removed. The same applies to the `<feature-app-loader>` and `<feature-app-container>` custom elements. Since the integrator now needs to define the ID of a Feature App, the Feature App definition must not specify an `id` anymore.