### PR TITLE
feat(all): pass full env to beforeCreate callback

### DIFF
--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -176,7 +176,7 @@ describe('FeatureAppManager', () => {
     });
 
     describe('with a beforeCreate callback', () => {
-      it('calls the beforeCreate callback prior to calling create', () => {
+      it('calls the beforeCreate callback with the same env that is passed to create, prior to calling create', () => {
         const featureAppId = 'testId';
 
         featureAppManager = new FeatureAppManager(mockFeatureServiceRegistry, {
@@ -203,11 +203,9 @@ describe('FeatureAppManager', () => {
           {beforeCreate: mockBeforeCreate}
         );
 
-        const {featureServices} = mockFeatureServicesBinding;
-
-        expect(mockBeforeCreate.mock.calls).toEqual([
-          [featureAppId, featureServices]
-        ]);
+        expect(mockBeforeCreate.mock.calls).toEqual(
+          mockFeatureAppCreate.mock.calls
+        );
       });
     });
 
@@ -440,11 +438,11 @@ describe('FeatureAppManager', () => {
             {beforeCreate: mockBeforeCreate}
           );
 
-          const {featureServices} = mockFeatureServicesBinding;
+          expect(mockBeforeCreate.mock.calls).toHaveLength(1);
 
-          expect(mockBeforeCreate.mock.calls).toEqual([
-            [featureAppId, featureServices]
-          ]);
+          expect(mockBeforeCreate.mock.calls).toEqual(
+            mockFeatureAppCreate.mock.calls
+          );
         });
 
         describe('when destroy() is called on the Feature App scope', () => {
@@ -472,12 +470,11 @@ describe('FeatureAppManager', () => {
               {beforeCreate: mockBeforeCreate}
             );
 
-            const {featureServices} = mockFeatureServicesBinding;
+            expect(mockBeforeCreate.mock.calls).toHaveLength(2);
 
-            expect(mockBeforeCreate.mock.calls).toEqual([
-              [featureAppId, featureServices],
-              [featureAppId, featureServices]
-            ]);
+            expect(mockBeforeCreate.mock.calls).toEqual(
+              mockFeatureAppCreate.mock.calls
+            );
           });
         });
       });

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -56,7 +56,10 @@ export interface FeatureAppScope<TFeatureApp> {
   destroy(): void;
 }
 
-export interface FeatureAppScopeOptions<TConfig> {
+export interface FeatureAppScopeOptions<
+  TFeatureServices extends FeatureServices,
+  TConfig
+> {
   /**
    * The absolute or relative base URL of the Feature App's assets and/or BFF.
    */
@@ -71,7 +74,7 @@ export interface FeatureAppScopeOptions<TConfig> {
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    env: FeatureAppEnvironment<FeatureServices, TConfig>
+    env: FeatureAppEnvironment<TFeatureServices, TConfig>
   ) => void;
 }
 
@@ -186,10 +189,18 @@ export class FeatureAppManager {
    * multiple times with the same [[FeatureAppDefinition]] and ID specifier,
    * it returns the [[FeatureAppScope]] it created on the first call.
    */
-  public getFeatureAppScope<TFeatureApp, TConfig>(
+  public getFeatureAppScope<
+    TFeatureApp,
+    TFeatureServices extends FeatureServices = FeatureServices,
+    TConfig = unknown
+  >(
     featureAppId: string,
-    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
-    options: FeatureAppScopeOptions<TConfig> = {}
+    featureAppDefinition: FeatureAppDefinition<
+      TFeatureApp,
+      TFeatureServices,
+      TConfig
+    >,
+    options: FeatureAppScopeOptions<TFeatureServices, TConfig> = {}
   ): FeatureAppScope<TFeatureApp> {
     let featureAppScope = this.featureAppScopes.get(featureAppId);
 
@@ -277,11 +288,19 @@ export class FeatureAppManager {
     );
   }
 
-  private createFeatureAppScope<TFeatureApp, TConfig>(
-    featureAppDefinition: FeatureAppDefinition<TFeatureApp>,
+  private createFeatureAppScope<
+    TFeatureApp,
+    TFeatureServices extends FeatureServices,
+    TConfig
+  >(
+    featureAppDefinition: FeatureAppDefinition<
+      TFeatureApp,
+      TFeatureServices,
+      TConfig
+    >,
     featureAppId: string,
     deleteFeatureAppScope: () => void,
-    options: FeatureAppScopeOptions<TConfig>
+    options: FeatureAppScopeOptions<TFeatureServices, TConfig>
   ): FeatureAppScope<TFeatureApp> {
     this.validateExternals(featureAppDefinition);
 
@@ -292,11 +311,11 @@ export class FeatureAppManager {
       featureAppId
     );
 
-    const env: FeatureAppEnvironment<FeatureServices, TConfig> = {
+    const env: FeatureAppEnvironment<TFeatureServices, TConfig> = {
       baseUrl,
       config,
       featureAppId,
-      featureServices: binding.featureServices
+      featureServices: binding.featureServices as TFeatureServices
     };
 
     if (beforeCreate) {

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -73,8 +73,10 @@ export interface SharedFeatureService {
   readonly [version: string]: FeatureServiceBinder<unknown> | undefined;
 }
 
-export interface FeatureServicesBinding {
-  readonly featureServices: FeatureServices;
+export interface FeatureServicesBinding<
+  TFeatureServices extends FeatureServices = FeatureServices
+> {
+  readonly featureServices: TFeatureServices;
 
   unbind(): void;
 }

--- a/packages/demos/src/custom-logging/app.tsx
+++ b/packages/demos/src/custom-logging/app.tsx
@@ -1,12 +1,11 @@
-import {FeatureServices} from '@feature-hub/core';
+import {FeatureAppEnvironment, FeatureServices} from '@feature-hub/core';
 import {FeatureAppContainer} from '@feature-hub/react';
 import * as React from 'react';
 import featureAppDefinition from './feature-app';
 
 export interface AppProps {
   readonly beforeCreate?: (
-    featureAppId: string,
-    featureServices: FeatureServices
+    env: FeatureAppEnvironment<FeatureServices, undefined>
   ) => void;
 }
 

--- a/packages/demos/src/custom-logging/integrator.tsx
+++ b/packages/demos/src/custom-logging/integrator.tsx
@@ -36,7 +36,7 @@ const logger = featureServices['s2:logger'] as Logger;
 ReactDOM.hydrate(
   <FeatureHubContextProvider value={{featureAppManager}}>
     <App
-      beforeCreate={featureAppId =>
+      beforeCreate={({featureAppId}) =>
         logger.debug(`Creating Feature App "${featureAppId}"...`)
       }
     />

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -12,12 +12,12 @@ import {
 import {Stubbed, stubMethods} from 'jest-stub-methods';
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
-import {FeatureAppContainer, FeatureHubContextProvider} from '..';
+import {FeatureApp, FeatureAppContainer, FeatureHubContextProvider} from '..';
 
 describe('FeatureAppContainer (on Node.js)', () => {
   let mockFeatureAppManager: FeatureAppManager;
   let mockGetFeatureAppScope: jest.Mock;
-  let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
+  let mockFeatureAppDefinition: FeatureAppDefinition<FeatureApp>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
   let stubbedConsole: Stubbed<Console>;
 

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -8,13 +8,13 @@ import {
 import {Stubbed, stubMethods} from 'jest-stub-methods';
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
-import {FeatureAppContainer, FeatureHubContextProvider} from '..';
+import {FeatureApp, FeatureAppContainer, FeatureHubContextProvider} from '..';
 import {logger} from './logger';
 
 describe('FeatureAppContainer', () => {
   let mockFeatureAppManager: FeatureAppManager;
   let mockGetFeatureAppScope: jest.Mock;
-  let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
+  let mockFeatureAppDefinition: FeatureAppDefinition<FeatureApp>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
   let stubbedConsole: Stubbed<Console>;
 
@@ -115,7 +115,7 @@ describe('FeatureAppContainer', () => {
       />
     );
 
-    const expectedOptions: FeatureAppScopeOptions<string> = {
+    const expectedOptions: FeatureAppScopeOptions<{}, string> = {
       baseUrl: '/base',
       config: 'testConfig',
       beforeCreate: mockBeforeCreate

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -115,7 +115,7 @@ describe('FeatureAppContainer', () => {
       />
     );
 
-    const expectedOptions: FeatureAppScopeOptions = {
+    const expectedOptions: FeatureAppScopeOptions<string> = {
       baseUrl: '/base',
       config: 'testConfig',
       beforeCreate: mockBeforeCreate

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -4,7 +4,7 @@ import {
   FeatureServices
 } from '@feature-hub/core';
 import * as React from 'react';
-import {FeatureAppContainer} from './feature-app-container';
+import {FeatureApp, FeatureAppContainer} from './feature-app-container';
 import {
   Css,
   FeatureHubContextConsumer,
@@ -12,7 +12,7 @@ import {
 } from './feature-hub-context';
 import {prependBaseUrl} from './internal/prepend-base-url';
 
-export interface FeatureAppLoaderProps<TConfig> {
+export interface FeatureAppLoaderProps<TConfig = unknown> {
   /**
    * The Feature App ID is used to identify the Feature App instance. Multiple
    * Feature App Loaders with the same `featureAppId` will render the same
@@ -77,7 +77,7 @@ const inBrowser =
   typeof document === 'object' &&
   document.nodeType === 9;
 
-class InternalFeatureAppLoader<TConfig> extends React.PureComponent<
+class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
   InternalFeatureAppLoaderProps<TConfig>,
   InternalFeatureAppLoaderState
 > {
@@ -199,7 +199,9 @@ class InternalFeatureAppLoader<TConfig> extends React.PureComponent<
         beforeCreate={beforeCreate}
         config={config}
         featureAppId={featureAppId}
-        featureAppDefinition={featureAppDefinition}
+        featureAppDefinition={
+          featureAppDefinition as FeatureAppDefinition<FeatureApp>
+        }
         onError={onError}
         renderError={renderError}
       />

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -1,4 +1,8 @@
-import {FeatureAppDefinition, FeatureServices} from '@feature-hub/core';
+import {
+  FeatureAppDefinition,
+  FeatureAppEnvironment,
+  FeatureServices
+} from '@feature-hub/core';
 import * as React from 'react';
 import {FeatureAppContainer} from './feature-app-container';
 import {
@@ -8,7 +12,7 @@ import {
 } from './feature-hub-context';
 import {prependBaseUrl} from './internal/prepend-base-url';
 
-export interface FeatureAppLoaderProps {
+export interface FeatureAppLoaderProps<TConfig> {
   /**
    * The Feature App ID is used to identify the Feature App instance. Multiple
    * Feature App Loaders with the same `featureAppId` will render the same
@@ -45,14 +49,13 @@ export interface FeatureAppLoaderProps {
   /**
    * A config object that is passed to the Feature App's `create` method.
    */
-  readonly config?: unknown;
+  readonly config?: TConfig;
 
   /**
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    featureAppId: string,
-    featureServices: FeatureServices
+    env: FeatureAppEnvironment<FeatureServices, TConfig>
   ) => void;
 
   readonly onError?: (error: Error) => void;
@@ -60,7 +63,7 @@ export interface FeatureAppLoaderProps {
   readonly renderError?: (error: Error) => React.ReactNode;
 }
 
-type InternalFeatureAppLoaderProps = FeatureAppLoaderProps &
+type InternalFeatureAppLoaderProps<TConfig> = FeatureAppLoaderProps<TConfig> &
   FeatureHubContextConsumerValue;
 
 interface InternalFeatureAppLoaderState {
@@ -74,8 +77,8 @@ const inBrowser =
   typeof document === 'object' &&
   document.nodeType === 9;
 
-class InternalFeatureAppLoader extends React.PureComponent<
-  InternalFeatureAppLoaderProps,
+class InternalFeatureAppLoader<TConfig> extends React.PureComponent<
+  InternalFeatureAppLoaderProps<TConfig>,
   InternalFeatureAppLoaderState
 > {
   public readonly state: InternalFeatureAppLoaderState = {};
@@ -83,7 +86,7 @@ class InternalFeatureAppLoader extends React.PureComponent<
   private errorHandled = false;
   private mounted = false;
 
-  public constructor(props: InternalFeatureAppLoaderProps) {
+  public constructor(props: InternalFeatureAppLoaderProps<TConfig>) {
     super(props);
 
     const {
@@ -302,11 +305,16 @@ class InternalFeatureAppLoader extends React.PureComponent<
  * `FeatureAppLoader` renders `null`. On the server, however, rendering
  * errors are not caught and must therefore be handled by the integrator.
  */
-export function FeatureAppLoader(props: FeatureAppLoaderProps): JSX.Element {
+export function FeatureAppLoader<TConfig>(
+  props: FeatureAppLoaderProps<TConfig>
+): JSX.Element {
   return (
     <FeatureHubContextConsumer>
       {featureHubContextValue => (
-        <InternalFeatureAppLoader {...featureHubContextValue} {...props} />
+        <InternalFeatureAppLoader<TConfig>
+          {...featureHubContextValue}
+          {...props}
+        />
       )}
     </FeatureHubContextConsumer>
   );


### PR DESCRIPTION
fixes #490

BREAKING CHANGE: Instead of passing the `featureAppId` and the `featureServices` as separate arguments to the `beforeCreate` callback, the full Feature App environment, that contains the `featureAppId` and `featureServices`, is now passed as a single argument (`env`). This is the same argument that is passed to the Feature App's `create` method.