### PR TITLE
feat(react): do not re-throw render errors on server

### DIFF
--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -21,14 +21,6 @@ describe('FeatureAppContainer (on Node.js)', () => {
   let mockFeatureAppScope: FeatureAppScope<unknown>;
   let stubbedConsole: Stubbed<Console>;
 
-  const noErrorBoundaryConsoleErrorCalls = [
-    [
-      expect.stringContaining(
-        'Consider adding an error boundary to your tree to customize error handling behavior.'
-      )
-    ]
-  ];
-
   const expectConsoleErrorCalls = (expectedConsoleErrorCalls: unknown[][]) => {
     try {
       expect(stubbedConsole.stub.error.mock.calls).toEqual(
@@ -84,24 +76,19 @@ describe('FeatureAppContainer (on Node.js)', () => {
         };
       });
 
-      it('logs and throws an error', () => {
+      it('logs an error', () => {
         const expectedError = new Error(
           'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.'
         );
 
-        expect(() =>
-          renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-            />
-          )
-        ).toThrowError(expectedError);
+        renderWithFeatureHubContext(
+          <FeatureAppContainer
+            featureAppId="testId"
+            featureAppDefinition={mockFeatureAppDefinition}
+          />
+        );
 
-        expectConsoleErrorCalls([
-          [expectedError],
-          ...noErrorBoundaryConsoleErrorCalls
-        ]);
+        expectConsoleErrorCalls([[expectedError]]);
       });
     });
   }
@@ -117,20 +104,15 @@ describe('FeatureAppContainer (on Node.js)', () => {
       });
     });
 
-    it('logs and throws an error', () => {
-      expect(() =>
-        renderWithFeatureHubContext(
-          <FeatureAppContainer
-            featureAppId="testId"
-            featureAppDefinition={mockFeatureAppDefinition}
-          />
-        )
-      ).toThrowError(mockError);
+    it('logs an error', () => {
+      renderWithFeatureHubContext(
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />
+      );
 
-      expectConsoleErrorCalls([
-        [mockError],
-        ...noErrorBoundaryConsoleErrorCalls
-      ]);
+      expectConsoleErrorCalls([[mockError]]);
     });
   });
 
@@ -150,20 +132,15 @@ describe('FeatureAppContainer (on Node.js)', () => {
       };
     });
 
-    it('logs and re-throws the error', () => {
-      expect(() =>
-        renderWithFeatureHubContext(
-          <FeatureAppContainer
-            featureAppId="testId"
-            featureAppDefinition={mockFeatureAppDefinition}
-          />
-        )
-      ).toThrowError(mockError);
+    it('logs the error', () => {
+      renderWithFeatureHubContext(
+        <FeatureAppContainer
+          featureAppId="testId"
+          featureAppDefinition={mockFeatureAppDefinition}
+        />
+      );
 
-      expectConsoleErrorCalls([
-        [mockError],
-        ...noErrorBoundaryConsoleErrorCalls
-      ]);
+      expectConsoleErrorCalls([[mockError]]);
     });
   });
 });

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -209,16 +209,14 @@ describe('FeatureAppLoader (on Node.js)', () => {
         mockAsyncFeatureAppDefinition.error = mockError;
       });
 
-      it('logs and re-throws the error', () => {
-        expect(() =>
-          renderWithFeatureHubContext(
-            <FeatureAppLoader
-              src="example.js"
-              serverSrc="example-node.js"
-              featureAppId="testId"
-            />
-          )
-        ).toThrowError(mockError);
+      it('logs the error', () => {
+        renderWithFeatureHubContext(
+          <FeatureAppLoader
+            src="example.js"
+            serverSrc="example-node.js"
+            featureAppId="testId"
+          />
+        );
 
         expect(stubbedConsole.stub.error.mock.calls).toEqual([
           [

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -103,11 +103,6 @@ type InternalFeatureAppContainerState<TFeatureApp extends FeatureApp> =
   | {readonly featureAppError: Error}
   | {readonly featureApp: TFeatureApp};
 
-const inBrowser =
-  typeof window === 'object' &&
-  typeof document === 'object' &&
-  document.nodeType === 9;
-
 class InternalFeatureAppContainer<
   TFeatureApp extends FeatureApp,
   TFeatureServices extends FeatureServices = FeatureServices,
@@ -219,14 +214,6 @@ class InternalFeatureAppContainer<
       onError(error);
     } else {
       logger.error(error);
-
-      /**
-       * @deprecated Should be handled instead by providing onError that throws.
-       * Remove this legacy branch for version 2.0 of @feature-hub/react.
-       */
-      if (!inBrowser) {
-        throw error;
-      }
     }
   }
 }

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -252,14 +252,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       this.props.onError(error);
     } else {
       this.logError(error);
-
-      /**
-       * @deprecated Should be handled instead by providing onError that throws.
-       * Remove this legacy branch for version 2.0 of @feature-hub/react.
-       */
-      if (!inBrowser) {
-        throw error;
-      }
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE: When the FeatureAppContainer/FeatureAppLoader catches a render error on the server, this error was previously re-thrown. To re-create this behavior, an `onError` prop must be defined that throws the error.