### PR TITLE
fix(all): remove all deprecated interfaces

### DIFF
--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -16,11 +16,6 @@ export interface AsyncSsrManagerOptions {
 }
 
 /**
- * @deprecated Use [[AsyncSsrManagerV1]] instead.
- */
-export type AsyncSsrManagerV0 = AsyncSsrManagerV1;
-
-/**
  * The Async SSR Manager enables the integrator to render a given composition
  * of React Feature Apps in multiple render passes until all Feature Apps and
  * Feature Services have finished their asynchronous operations.

--- a/packages/core/src/externals-validator.ts
+++ b/packages/core/src/externals-validator.ts
@@ -16,11 +16,6 @@ export interface RequiredExternals {
 }
 
 /**
- * @deprecated Use [[ExternalsValidator]] instead.
- */
-export type ExternalsValidatorLike = ExternalsValidator;
-
-/**
  * The `ExternalsValidator` validates required externals against the provided
  * set of externals it is initilized with.
  */

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -78,11 +78,6 @@ export interface FeatureAppScopeOptions<
   ) => void;
 }
 
-/**
- * @deprecated Use [[FeatureAppManager]] instead.
- */
-export type FeatureAppManagerLike = FeatureAppManager;
-
 export interface FeatureAppManagerOptions {
   /**
    * For the `FeatureAppManager` to be able to load Feature Apps from a remote

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -81,11 +81,6 @@ export interface FeatureServicesBinding<
   unbind(): void;
 }
 
-/**
- * @deprecated Use [[FeatureServiceRegistry]] instead.
- */
-export type FeatureServiceRegistryLike = FeatureServiceRegistry;
-
 export interface FeatureServiceRegistryOptions {
   /**
    * If the [[FeatureAppManager]] is configured with a

--- a/packages/history-service/src/define-history-service.ts
+++ b/packages/history-service/src/define-history-service.ts
@@ -12,11 +12,6 @@ import {createHistoryMultiplexers} from './internal/create-history-multiplexers'
 import {createHistoryServiceV1Binder} from './internal/create-history-service-v1-binder';
 import {createHistoryServiceContext} from './internal/history-service-context';
 
-/**
- * @deprecated Use [[HistoryServiceV1]] instead.
- */
-export type HistoryServiceV0 = HistoryServiceV1;
-
 export interface HistoryServiceV1 {
   readonly staticRootLocation: history.Location;
 

--- a/packages/react/src/feature-hub-context.tsx
+++ b/packages/react/src/feature-hub-context.tsx
@@ -51,12 +51,6 @@ export interface FeatureHubContextProviderValue {
   addStylesheetsForSsr?(stylesheets: Css[]): void;
 }
 
-/**
- * @deprecated Use [[FeatureHubContextProviderValue]] or
- * [[FeatureHubContextConsumerValue]] instead.
- */
-export type FeatureHubContextValue = FeatureHubContextProviderValue;
-
 export type FeatureHubContextConsumerValue = SomeRequired<
   FeatureHubContextProviderValue,
   'logger'

--- a/packages/serialized-state-manager/src/index.ts
+++ b/packages/serialized-state-manager/src/index.ts
@@ -7,11 +7,6 @@ import {ClientSideStateManager} from './internal/client-side-state-manager';
 import {SerializedStateManager} from './internal/serialized-state-manager';
 import {ServerSideStateManager} from './internal/server-side-state-manager';
 
-/**
- * @deprecated Use [[SerializedStateManagerV1]] instead.
- */
-export type SerializedStateManagerV0 = SerializedStateManagerV1;
-
 export interface SerializedStateManagerV1 {
   /**
    * This method is intended to be called by consumers, i.e. Feature Apps and

--- a/packages/server-request/src/index.ts
+++ b/packages/server-request/src/index.ts
@@ -4,11 +4,6 @@ import {
   SharedFeatureService
 } from '@feature-hub/core';
 
-/**
- * @deprecated Use [[ServerRequestV1]] instead.
- */
-export type ServerRequestV0 = ServerRequestV1;
-
 export interface ServerRequestV1 {
   readonly url: string;
   readonly cookies: Record<string, string>;


### PR DESCRIPTION
BREAKING CHANGE: The following interfaces have been removed:
- AsyncSsrManagerV0
- ExternalsValidatorLike
- FeatureAppManagerLike
- FeatureServiceRegistryLike
- HistoryServiceV0
- FeatureHubContextValue
- SerializedStateManagerV0
- ServerRequestV0