### PR TITLE
fix(history-service): reorder createRootLocation params

### DIFF
--- a/packages/demos/src/history-service/root-location-transformer.ts
+++ b/packages/demos/src/history-service/root-location-transformer.ts
@@ -9,7 +9,7 @@ export const rootLocationTransformer: RootLocationTransformer = {
     return searchParams.get(consumerId) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
+  createRootLocation: (rootLocation, consumerLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {

--- a/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
+++ b/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
@@ -10,17 +10,17 @@ describe('#createRootLocationTransformer', () => {
         });
 
         let rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo'} as Location,
           {pathname: '/'} as Location,
+          {pathname: '/foo'} as Location,
           'test:1'
         );
 
         rootLocation = locationTransformer.createRootLocation(
+          rootLocation as Location,
           {
             pathname: '/bar',
             search: 'baz=1'
           } as Location,
-          rootLocation as Location,
           'test:2'
         );
 
@@ -37,17 +37,17 @@ describe('#createRootLocationTransformer', () => {
         });
 
         let rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo'} as Location,
           {
             pathname: '/',
             search: '---=%7B%22test%3A2%22%3A%22%2Fbar%22%7D'
           } as Location,
+          {pathname: '/foo'} as Location,
           'test:1'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          undefined,
           rootLocation as Location,
+          undefined,
           'test:1'
         );
 
@@ -63,20 +63,20 @@ describe('#createRootLocationTransformer', () => {
         });
 
         let rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo'} as Location,
           {pathname: '/'} as Location,
+          {pathname: '/foo'} as Location,
           'test:1'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          undefined,
           rootLocation as Location,
+          undefined,
           'test:1'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          undefined,
           rootLocation as Location,
+          undefined,
           'test:1'
         );
 
@@ -95,8 +95,8 @@ describe('#createRootLocationTransformer', () => {
         });
 
         const rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo', search: 'bar=1&baz=2', hash: '#qux'} as Location,
           {pathname: '/'} as Location,
+          {pathname: '/foo', search: 'bar=1&baz=2', hash: '#qux'} as Location,
           'test:pri'
         );
 
@@ -114,14 +114,14 @@ describe('#createRootLocationTransformer', () => {
         });
 
         let rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo', search: 'bar=1&baz=2', hash: '#qux'} as Location,
           {pathname: '/'} as Location,
+          {pathname: '/foo', search: 'bar=1&baz=2', hash: '#qux'} as Location,
           'test:pri'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          undefined,
           rootLocation as Location,
+          undefined,
           'test:pri'
         );
 
@@ -137,8 +137,8 @@ describe('#createRootLocationTransformer', () => {
 
           expect(() =>
             locationTransformer.createRootLocation(
-              {pathname: '/foo', search: '---=1'} as Location,
               {pathname: '/'} as Location,
+              {pathname: '/foo', search: '---=1'} as Location,
               'test:pri'
             )
           ).toThrowError(
@@ -158,20 +158,20 @@ describe('#createRootLocationTransformer', () => {
         });
 
         let rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/baz', search: 'qux=3'} as Location,
           {pathname: '/'} as Location,
+          {pathname: '/baz', search: 'qux=3'} as Location,
           'test:1'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/foo', search: 'bar=1', hash: '#qux'} as Location,
           rootLocation as Location,
+          {pathname: '/foo', search: 'bar=1', hash: '#qux'} as Location,
           'test:pri'
         );
 
         rootLocation = locationTransformer.createRootLocation(
-          {pathname: '/some', search: 'thing=else'} as Location,
           rootLocation as Location,
+          {pathname: '/some', search: 'thing=else'} as Location,
           'test:2'
         );
 

--- a/packages/history-service/src/create-root-location-transformer.ts
+++ b/packages/history-service/src/create-root-location-transformer.ts
@@ -18,8 +18,8 @@ export interface RootLocationTransformer {
   ): string | undefined;
 
   createRootLocation(
-    consumerLocation: history.Location | undefined,
     currentRootLocation: history.Location,
+    consumerLocation: history.Location | undefined,
     consumerId: string
   ): history.LocationDescriptorObject;
 }
@@ -129,8 +129,8 @@ export function createRootLocationTransformer(
     },
 
     createRootLocation: (
-      consumerLocation: history.Location | undefined,
       currentRootLocation: history.Location,
+      consumerLocation: history.Location | undefined,
       consumerId: string
     ): history.LocationDescriptorObject => {
       const {consumerPathsQueryParamName, primaryConsumerId} = options;

--- a/packages/history-service/src/internal/history-multiplexer.ts
+++ b/packages/history-service/src/internal/history-multiplexer.ts
@@ -81,8 +81,8 @@ export class HistoryMultiplexer {
     consumerLocation: history.Location | undefined
   ): history.Location {
     const rootLocation = this.rootLocationTransformer.createRootLocation(
-      consumerLocation,
       this.rootHistory.location,
+      consumerLocation,
       consumerId
     );
 

--- a/packages/history-service/src/internal/test-root-location-transformer.ts
+++ b/packages/history-service/src/internal/test-root-location-transformer.ts
@@ -9,7 +9,7 @@ export const testRootLocationTransformer: RootLocationTransformer = {
     return searchParams.get(consumerId) || undefined;
   },
 
-  createRootLocation: (consumerLocation, rootLocation, consumerId) => {
+  createRootLocation: (rootLocation, consumerLocation, consumerId) => {
     const searchParams = new URLSearchParams(rootLocation.search);
 
     if (consumerLocation) {


### PR DESCRIPTION
BREAKING CHANGE: The `currentRootLocation` and `consumerLocation` parameters of `createRootLocation` have been switched.