### PR TITLE
fix(all): do not destroy Feature App when it is rendered multiple times

### DIFF
--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -77,7 +77,7 @@ describe('createFeatureHub()', () => {
     });
   });
 
-  describe('featureAppManager#getFeatureAppScope', () => {
+  describe('featureAppManager#createFeatureAppScope', () => {
     let mockFeatureApp: {};
     let mockFeatureAppCreate: jest.Mock;
     let mockFeatureAppDefinition: FeatureAppDefinition<unknown>;
@@ -98,7 +98,7 @@ describe('createFeatureHub()', () => {
         featureHubOptions
       );
 
-      const {featureApp} = featureAppManager.getFeatureAppScope(
+      const {featureApp} = featureAppManager.createFeatureAppScope(
         'test:feature-app',
         mockFeatureAppDefinition
       );
@@ -123,7 +123,7 @@ describe('createFeatureHub()', () => {
         );
 
         expect(() =>
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             'test:feature-app',
             mockFeatureAppDefinition
           )
@@ -253,7 +253,7 @@ describe('createFeatureHub()', () => {
           logger
         });
 
-        featureAppManager.getFeatureAppScope(
+        featureAppManager.createFeatureAppScope(
           'test:feature-app',
           featureAppDefinition
         );
@@ -278,7 +278,7 @@ describe('createFeatureHub()', () => {
           featureServiceDefinitions
         });
 
-        featureAppManager.getFeatureAppScope(
+        featureAppManager.createFeatureAppScope(
           'test:feature-app',
           featureAppDefinition
         );

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -148,7 +148,7 @@ describe('FeatureAppManager', () => {
     });
   });
 
-  describe('#getFeatureAppScope', () => {
+  describe('#createFeatureAppScope', () => {
     it('creates a Feature App with a consumer environment using the Feature Service registry', () => {
       const featureAppId = 'testId';
       const config = 'testConfig';
@@ -158,7 +158,7 @@ describe('FeatureAppManager', () => {
         logger
       });
 
-      featureAppManager.getFeatureAppScope(
+      featureAppManager.createFeatureAppScope(
         featureAppId,
         mockFeatureAppDefinition,
         {baseUrl, config}
@@ -197,7 +197,7 @@ describe('FeatureAppManager', () => {
           return mockFeatureApp;
         });
 
-        featureAppManager.getFeatureAppScope(
+        featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
           {beforeCreate: mockBeforeCreate}
@@ -224,7 +224,7 @@ describe('FeatureAppManager', () => {
 
         it("doesn't throw an error", () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               'testId',
               mockFeatureAppDefinition
             );
@@ -263,7 +263,7 @@ describe('FeatureAppManager', () => {
 
         it('calls the provided ExternalsValidator with the defined externals', () => {
           try {
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               'testId',
               mockFeatureAppDefinition
             );
@@ -276,7 +276,7 @@ describe('FeatureAppManager', () => {
 
         it('throws the validation error', () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               'testId',
               mockFeatureAppDefinition
             );
@@ -297,7 +297,7 @@ describe('FeatureAppManager', () => {
         });
 
         it('calls the provided ExternalsValidator with the defined externals', () => {
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             'testId',
             mockFeatureAppDefinition
           );
@@ -309,7 +309,7 @@ describe('FeatureAppManager', () => {
 
         it("doesn't throw an error", () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               'testId',
               mockFeatureAppDefinition
             );
@@ -319,7 +319,7 @@ describe('FeatureAppManager', () => {
 
       describe('with a Feature App definition that declares no externals', () => {
         it('does not call the provided ExternalsValidator', () => {
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             'testId',
             mockFeatureAppDefinition
           );
@@ -329,7 +329,7 @@ describe('FeatureAppManager', () => {
 
         it("doesn't throw an error", () => {
           expect(() => {
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               'testId',
               mockFeatureAppDefinition
             );
@@ -353,7 +353,7 @@ describe('FeatureAppManager', () => {
 
       it('throws the same error', () => {
         expect(() =>
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             'testId',
             mockFeatureAppDefinition
           )
@@ -392,7 +392,7 @@ describe('FeatureAppManager', () => {
       it("registers the Feature App's own Feature Services before binding its required Feature Services", () => {
         const featureAppId = 'testId';
 
-        featureAppManager.getFeatureAppScope(
+        featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition
         );
@@ -426,13 +426,13 @@ describe('FeatureAppManager', () => {
 
           const mockBeforeCreate = jest.fn();
 
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             featureAppId,
             mockFeatureAppDefinition,
             {beforeCreate: mockBeforeCreate}
           );
 
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             featureAppId,
             mockFeatureAppDefinition,
             {beforeCreate: mockBeforeCreate}
@@ -445,7 +445,7 @@ describe('FeatureAppManager', () => {
           );
         });
 
-        describe('when destroy() is called on the Feature App scope', () => {
+        describe('when release() is called on the Feature App scope', () => {
           it('calls the beforeCreate callback again', () => {
             const featureAppId = 'testId';
 
@@ -456,15 +456,15 @@ describe('FeatureAppManager', () => {
 
             const mockBeforeCreate = jest.fn();
 
-            const featureAppScope = featureAppManager.getFeatureAppScope(
+            const featureAppScope = featureAppManager.createFeatureAppScope(
               featureAppId,
               mockFeatureAppDefinition,
               {beforeCreate: mockBeforeCreate}
             );
 
-            featureAppScope.destroy();
+            featureAppScope.release();
 
-            featureAppManager.getFeatureAppScope(
+            featureAppManager.createFeatureAppScope(
               featureAppId,
               mockFeatureAppDefinition,
               {beforeCreate: mockBeforeCreate}
@@ -480,7 +480,7 @@ describe('FeatureAppManager', () => {
       });
 
       it('logs an info message after creation', () => {
-        featureAppManager.getFeatureAppScope(
+        featureAppManager.createFeatureAppScope(
           'testId',
           mockFeatureAppDefinition
         );
@@ -492,42 +492,24 @@ describe('FeatureAppManager', () => {
         ]);
       });
 
-      it('returns the same Feature App scope', () => {
-        const featureAppScope = featureAppManager.getFeatureAppScope(
+      it('returns a new Feature App scope', () => {
+        const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
           mockFeatureAppDefinition
         );
 
         expect(
-          featureAppManager.getFeatureAppScope(
+          featureAppManager.createFeatureAppScope(
             'testId',
             mockFeatureAppDefinition
           )
-        ).toBe(featureAppScope);
-      });
-
-      describe('when destroy() is called on the Feature App scope', () => {
-        it('returns another Feature App scope', () => {
-          const featureAppScope = featureAppManager.getFeatureAppScope(
-            'testId',
-            mockFeatureAppDefinition
-          );
-
-          featureAppScope.destroy();
-
-          expect(
-            featureAppManager.getFeatureAppScope(
-              'testId',
-              mockFeatureAppDefinition
-            )
-          ).not.toBe(featureAppScope);
-        });
+        ).not.toBe(featureAppScope);
       });
     });
 
     describe('#featureApp', () => {
       it("is the Feature App that the Feature App definition's create returns", () => {
-        const featureAppScope = featureAppManager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
           mockFeatureAppDefinition
         );
@@ -536,50 +518,52 @@ describe('FeatureAppManager', () => {
       });
     });
 
-    describe('#destroy', () => {
+    describe('#release', () => {
       it('unbinds the bound Feature Services', () => {
-        const featureAppScope = featureAppManager.getFeatureAppScope(
+        const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
           mockFeatureAppDefinition
         );
 
-        featureAppScope.destroy();
+        featureAppScope.release();
 
         expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(1);
       });
 
-      it('throws an error when destroy is called multiple times', () => {
-        const featureAppScope = featureAppManager.getFeatureAppScope(
-          'testId',
-          mockFeatureAppDefinition
-        );
+      describe('when createFeatureAppScope has been called two times', () => {
+        it('unbinds the bound Feature Services after the second scope has been released', () => {
+          const featureAppScope1 = featureAppManager.createFeatureAppScope(
+            'testId',
+            mockFeatureAppDefinition
+          );
 
-        featureAppScope.destroy();
+          const featureAppScope2 = featureAppManager.createFeatureAppScope(
+            'testId',
+            mockFeatureAppDefinition
+          );
 
-        expect(() => featureAppScope.destroy()).toThrowError(
-          new Error(
-            'The Feature App with the ID "testId" could not be destroyed.'
-          )
-        );
+          featureAppScope1.release();
+          expect(mockFeatureServicesBindingUnbind).not.toHaveBeenCalled();
+
+          featureAppScope2.release();
+          expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(1);
+        });
       });
 
-      it('fails to destroy an already destroyed Feature App scope, even if this scope has been re-created', () => {
-        const featureAppScope = featureAppManager.getFeatureAppScope(
+      it('logs a warning when release is called multiple times', () => {
+        const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
           mockFeatureAppDefinition
         );
 
-        featureAppScope.destroy();
-        featureAppManager.getFeatureAppScope(
-          'testId',
-          mockFeatureAppDefinition
-        );
+        featureAppScope.release();
+        featureAppScope.release();
 
-        expect(() => featureAppScope.destroy()).toThrowError(
-          new Error(
-            'The Feature App with the ID "testId" could not be destroyed.'
-          )
-        );
+        expect(logger.warn.mock.calls).toEqual([
+          [
+            'The Feature App with the ID "testId" has already been released for this scope.'
+          ]
+        ]);
       });
     });
   });
@@ -626,7 +610,10 @@ describe('FeatureAppManager', () => {
     });
 
     it('logs messages using the console', () => {
-      featureAppManager.getFeatureAppScope('testId', mockFeatureAppDefinition);
+      featureAppManager.createFeatureAppScope(
+        'testId',
+        mockFeatureAppDefinition
+      );
 
       expect(stubbedConsole.stub.info.mock.calls).toEqual([
         ['The Feature App with the ID "testId" has been successfully created.']

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -501,8 +501,8 @@ describe('FeatureAppManager', () => {
           mockFeatureAppDefinition
         );
 
-        expect(featureAppScope1).not.toBe(featureAppScope2);
-        expect(featureAppScope1.featureApp).toBe(featureAppScope2.featureApp);
+        expect(featureAppScope2).not.toBe(featureAppScope1);
+        expect(featureAppScope2.featureApp).toBe(featureAppScope1.featureApp);
       });
     });
 

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -104,7 +104,7 @@ export function defineFeatureAppContainer(
       }
 
       try {
-        this.featureAppScope = featureAppManager.getFeatureAppScope(
+        this.featureAppScope = featureAppManager.createFeatureAppScope(
           this.featureAppId,
           this.featureAppDefinition,
           {baseUrl: this.baseUrl, config: this.config}
@@ -132,7 +132,7 @@ export function defineFeatureAppContainer(
 
     public disconnectedCallback(): void {
       if (this.featureAppScope) {
-        this.featureAppScope.destroy();
+        this.featureAppScope.release();
       }
 
       super.disconnectedCallback();

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -16,7 +16,7 @@ import {FeatureApp, FeatureAppContainer, FeatureHubContextProvider} from '..';
 
 describe('FeatureAppContainer (on Node.js)', () => {
   let mockFeatureAppManager: FeatureAppManager;
-  let mockGetFeatureAppScope: jest.Mock;
+  let mockCreateFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<FeatureApp>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
   let stubbedConsole: Stubbed<Console>;
@@ -33,12 +33,12 @@ describe('FeatureAppContainer (on Node.js)', () => {
 
   beforeEach(() => {
     mockFeatureAppDefinition = {create: jest.fn()};
-    mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
-    mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
+    mockFeatureAppScope = {featureApp: {}, release: jest.fn()};
+    mockCreateFeatureAppScope = jest.fn(() => ({...mockFeatureAppScope}));
 
     mockFeatureAppManager = ({
       getAsyncFeatureAppDefinition: jest.fn(),
-      getFeatureAppScope: mockGetFeatureAppScope,
+      createFeatureAppScope: mockCreateFeatureAppScope,
       preloadFeatureApp: jest.fn()
     } as Partial<FeatureAppManager>) as FeatureAppManager;
 
@@ -72,7 +72,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
       beforeEach(() => {
         mockFeatureAppScope = {
           featureApp: invalidFeatureApp,
-          destroy: jest.fn()
+          release: jest.fn()
         };
       });
 
@@ -99,7 +99,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
     beforeEach(() => {
       mockError = new Error('Failed to create Feature App scope.');
 
-      mockGetFeatureAppScope.mockImplementation(() => {
+      mockCreateFeatureAppScope.mockImplementation(() => {
         throw mockError;
       });
     });

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -13,7 +13,7 @@ import {logger} from './logger';
 
 describe('FeatureAppContainer', () => {
   let mockFeatureAppManager: FeatureAppManager;
-  let mockGetFeatureAppScope: jest.Mock;
+  let mockCreateFeatureAppScope: jest.Mock;
   let mockFeatureAppDefinition: FeatureAppDefinition<FeatureApp>;
   let mockFeatureAppScope: FeatureAppScope<unknown>;
   let stubbedConsole: Stubbed<Console>;
@@ -48,12 +48,12 @@ describe('FeatureAppContainer', () => {
   beforeEach(() => {
     stubbedConsole = stubMethods(console);
     mockFeatureAppDefinition = {create: jest.fn()};
-    mockFeatureAppScope = {featureApp: {}, destroy: jest.fn()};
-    mockGetFeatureAppScope = jest.fn(() => mockFeatureAppScope);
+    mockFeatureAppScope = {featureApp: {}, release: jest.fn()};
+    mockCreateFeatureAppScope = jest.fn(() => ({...mockFeatureAppScope}));
 
     mockFeatureAppManager = ({
       getAsyncFeatureAppDefinition: jest.fn(),
-      getFeatureAppScope: mockGetFeatureAppScope,
+      createFeatureAppScope: mockCreateFeatureAppScope,
       preloadFeatureApp: jest.fn()
     } as Partial<FeatureAppManager>) as FeatureAppManager;
   });
@@ -121,7 +121,7 @@ describe('FeatureAppContainer', () => {
       beforeCreate: mockBeforeCreate
     };
 
-    expect(mockGetFeatureAppScope.mock.calls).toEqual([
+    expect(mockCreateFeatureAppScope.mock.calls).toEqual([
       ['testId', mockFeatureAppDefinition, expectedOptions]
     ]);
   });
@@ -132,7 +132,7 @@ describe('FeatureAppContainer', () => {
         featureApp: {
           render: () => <div>This is the React Feature App.</div>
         },
-        destroy: jest.fn()
+        release: jest.fn()
       };
     });
 
@@ -460,7 +460,7 @@ describe('FeatureAppContainer', () => {
     });
 
     describe('when unmounted', () => {
-      it('calls destroy() on the Feature App scope', () => {
+      it('calls release() on the Feature App scope', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
             featureAppId="testId"
@@ -468,20 +468,20 @@ describe('FeatureAppContainer', () => {
           />
         );
 
-        expect(mockFeatureAppScope.destroy).not.toHaveBeenCalled();
+        expect(mockFeatureAppScope.release).not.toHaveBeenCalled();
 
         testRenderer.unmount();
 
-        expect(mockFeatureAppScope.destroy).toHaveBeenCalledTimes(1);
+        expect(mockFeatureAppScope.release).toHaveBeenCalledTimes(1);
       });
 
       describe('when the Feature App scope throws an error while being destroyed', () => {
         let mockError: Error;
 
         beforeEach(() => {
-          mockError = new Error('Failed to destroy Feature App scope');
+          mockError = new Error('Failed to release Feature App');
 
-          mockFeatureAppScope.destroy = () => {
+          mockFeatureAppScope.release = () => {
             throw mockError;
           };
         });
@@ -571,7 +571,7 @@ describe('FeatureAppContainer', () => {
             container.innerHTML = 'This is the DOM Feature App.';
           }
         },
-        destroy: jest.fn()
+        release: jest.fn()
       };
     });
 
@@ -734,7 +734,7 @@ describe('FeatureAppContainer', () => {
     });
 
     describe('when unmounted', () => {
-      it('calls destroy() on the Feature App scope', () => {
+      it('calls release() on the Feature App scope', () => {
         const testRenderer = renderWithFeatureHubContext(
           <FeatureAppContainer
             featureAppId="testId"
@@ -742,20 +742,20 @@ describe('FeatureAppContainer', () => {
           />
         );
 
-        expect(mockFeatureAppScope.destroy).not.toHaveBeenCalled();
+        expect(mockFeatureAppScope.release).not.toHaveBeenCalled();
 
         testRenderer.unmount();
 
-        expect(mockFeatureAppScope.destroy).toHaveBeenCalledTimes(1);
+        expect(mockFeatureAppScope.release).toHaveBeenCalledTimes(1);
       });
 
-      describe('when the Feature App scope throws an error while being destroyed', () => {
+      describe('when the Feature App scope throws an error while being released', () => {
         let mockError: Error;
 
         beforeEach(() => {
-          mockError = new Error('Failed to destroy Feature App scope');
+          mockError = new Error('Failed to release Feature App');
 
-          mockFeatureAppScope.destroy = () => {
+          mockFeatureAppScope.release = () => {
             throw mockError;
           };
         });
@@ -807,7 +807,7 @@ describe('FeatureAppContainer', () => {
       beforeEach(() => {
         mockFeatureAppScope = {
           featureApp: invalidFeatureApp,
-          destroy: jest.fn()
+          release: jest.fn()
         };
       });
 
@@ -836,7 +836,7 @@ describe('FeatureAppContainer', () => {
     beforeEach(() => {
       mockError = new Error('Failed to create Feature App scope.');
 
-      mockGetFeatureAppScope.mockImplementation(() => {
+      mockCreateFeatureAppScope.mockImplementation(() => {
         throw mockError;
       });
     });

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -43,7 +43,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
     mockFeatureAppManager = ({
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
-      getFeatureAppScope: jest.fn(),
+      createFeatureAppScope: jest.fn(),
       preloadFeatureApp: jest.fn()
     } as Partial<FeatureAppManager>) as FeatureAppManager;
 

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -74,7 +74,7 @@ describe('FeatureAppLoader', () => {
 
     mockFeatureAppManager = ({
       getAsyncFeatureAppDefinition: mockGetAsyncFeatureAppDefinition,
-      getFeatureAppScope: jest.fn(),
+      createFeatureAppScope: jest.fn(),
       preloadFeatureApp: jest.fn()
     } as Partial<FeatureAppManager>) as FeatureAppManager;
 

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -133,7 +133,7 @@ class InternalFeatureAppContainer<
     } = props;
 
     try {
-      this.featureAppScope = featureAppManager.getFeatureAppScope(
+      this.featureAppScope = featureAppManager.createFeatureAppScope(
         featureAppId,
         featureAppDefinition,
         {baseUrl, config, beforeCreate}
@@ -178,7 +178,7 @@ class InternalFeatureAppContainer<
   public componentWillUnmount(): void {
     if (this.featureAppScope) {
       try {
-        this.featureAppScope.destroy();
+        this.featureAppScope.release();
       } catch (error) {
         this.handleError(error);
       }


### PR DESCRIPTION
fixes #505

BREAKING CHANGE: `FeatureAppManager#getFeatureAppScope` has been replaced by `FeatureAppManager#createFeatureAppScope`, since now a new `FeatureAppScope` is created for every call. When a Feature App is unmounted, the `release` method (previously called `destroy`) must be called. Only when all scopes for a Feature App ID have been released, the Feature App instance is destroyed.