### PR TITLE
fix(demos): increase feature-hub version in externals

### DIFF
--- a/packages/demos/src/feature-app-in-feature-app/feature-app-inner.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/feature-app-inner.tsx
@@ -7,7 +7,7 @@ const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
   dependencies: {
     externals: {
       react: '^16.7.0',
-      '@feature-hub/react': '^1.2.0'
+      '@feature-hub/react': '^2.0.0'
     }
   },
 

--- a/packages/demos/src/feature-app-in-feature-app/feature-app-outer.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/feature-app-outer.tsx
@@ -8,7 +8,7 @@ const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
   dependencies: {
     externals: {
       react: '^16.7.0',
-      '@feature-hub/react': '^1.2.0'
+      '@feature-hub/react': '^2.0.0'
     }
   },
 


### PR DESCRIPTION
The error got into `master` with the release that was created by Travis (increasing the `@feature-hub/core` version). 🙄