### PR TITLE
fix(core): avoid wrong featureServiceAlreadyRegistered logs

### DIFF
--- a/packages/core/src/__tests__/feature-service-registry.test.ts
+++ b/packages/core/src/__tests__/feature-service-registry.test.ts
@@ -147,31 +147,38 @@ describe('FeatureServiceRegistry', () => {
       testRegistrationOrderABC();
     });
 
-    it('does not register the already existing Feature Service "a"', () => {
+    it('does not register the already existing Feature Service "b"', () => {
       featureServiceRegistry.registerFeatureServices(
-        [providerDefinitionA],
+        [providerDefinitionA, providerDefinitionB],
         'test'
       );
       featureServiceRegistry.registerFeatureServices(
-        [providerDefinitionA],
+        [providerDefinitionB],
         'test'
       );
 
-      expect(providerDefinitionA.create.mock.calls).toEqual([
-        [{featureServices: {}}]
+      expect(providerDefinitionB.create.mock.calls).toEqual([
+        [{featureServices: {a: featureServiceA}}]
       ]);
 
-      expect(binderA.mock.calls).toEqual([]);
+      expect(binderA.mock.calls).toEqual([['b']]);
+      expect(binderB.mock.calls).toEqual([]);
 
       expect(logger.info.mock.calls).toEqual([
         [
           'The Feature Service "a" has been successfully registered by registrant "test".'
+        ],
+        [
+          'The required Feature Service "a" has been successfully bound to consumer "b".'
+        ],
+        [
+          'The Feature Service "b" has been successfully registered by registrant "test".'
         ]
       ]);
 
       expect(logger.warn.mock.calls).toEqual([
         [
-          'The already registered Feature Service "a" could not be re-registered by registrant "test".'
+          'The already registered Feature Service "b" could not be re-registered by registrant "test".'
         ]
       ]);
     });

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -308,32 +308,38 @@ export class FeatureServiceRegistry {
   ): void {
     const providerDefinition = providerDefinitionsById.get(providerId);
 
+    if (!providerDefinition) {
+      return;
+    }
+
     if (this.sharedFeatureServices.has(providerId)) {
       this.logger.warn(
         Messages.featureServiceAlreadyRegistered(providerId, registrantId)
       );
-    } else if (providerDefinition) {
-      this.validateExternals(providerDefinition);
 
-      const {featureServices} = this.bindFeatureServices(
-        providerDefinition,
-        providerId
-      );
-
-      const sharedFeatureService = providerDefinition.create({featureServices});
-
-      this.validateFeatureServiceVersions(
-        sharedFeatureService,
-        providerId,
-        registrantId
-      );
-
-      this.sharedFeatureServices.set(providerId, sharedFeatureService);
-
-      this.logger.info(
-        Messages.featureServiceSuccessfullyRegistered(providerId, registrantId)
-      );
+      return;
     }
+
+    this.validateExternals(providerDefinition);
+
+    const {featureServices} = this.bindFeatureServices(
+      providerDefinition,
+      providerId
+    );
+
+    const sharedFeatureService = providerDefinition.create({featureServices});
+
+    this.validateFeatureServiceVersions(
+      sharedFeatureService,
+      providerId,
+      registrantId
+    );
+
+    this.sharedFeatureServices.set(providerId, sharedFeatureService);
+
+    this.logger.info(
+      Messages.featureServiceSuccessfullyRegistered(providerId, registrantId)
+    );
   }
 
   private bindFeatureService(


### PR DESCRIPTION
If a feature service with dependencies is registered and those dependencies have already been registered beforehand, do not log that those dependent feature services are already registered and can not be re-registered. They are not tried to be registered anyway.