### PR TITLE
feat(module-loader-commonjs): add proxy support

### DIFF
--- a/packages/module-loader-commonjs/src/index.ts
+++ b/packages/module-loader-commonjs/src/index.ts
@@ -1,15 +1,16 @@
 import {ModuleLoader} from '@feature-hub/core';
-import fetch from 'node-fetch';
+import fetch, {RequestInit} from 'node-fetch';
 
 export interface Externals {
   readonly [externalName: string]: unknown;
 }
 
 export function createCommonJsModuleLoader(
-  externals: Externals = {}
+  externals: Externals = {},
+  requestInit?: RequestInit
 ): ModuleLoader {
   return async (url: string): Promise<unknown> => {
-    const response = await fetch(url);
+    const response = await fetch(url, requestInit);
     const source = await response.text();
     const mod = {exports: {}};
 


### PR DESCRIPTION
Dear Feature Hub team,

We at Das Büro am Draht need to load Feature Apps via proxy.

The dependency `node-fetch` does not consider proxy settings that are defined by environment variable (`process.env.HTTP_PROXY`).

Also, it seems that the team around `node-fetch` won't ever add proxy support. Please see this issue for further information: https://github.com/node-fetch/node-fetch/issues/195

So, with this pull request I add proxy support to the module loader by adding a proxy agent to the request.

What do you think? I hope you like the feature and its implementation.

Looking forward to hearing from you.

Thanks in advance and kind regards
Niels Garve (Das Büro am Draht)