### PR TITLE
fix(core): don't fail if feature service cannot be registered

### DIFF
--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -421,7 +421,11 @@ describe('FeatureAppManager', () => {
         expect(
           mockFeatureServiceRegistry.registerFeatureServices.mock.calls
         ).toEqual([
-          [mockFeatureAppDefinition.ownFeatureServiceDefinitions, featureAppId]
+          [
+            mockFeatureAppDefinition.ownFeatureServiceDefinitions,
+            featureAppId,
+            true
+          ]
         ]);
 
         expect(

--- a/packages/core/src/create-feature-hub.ts
+++ b/packages/core/src/create-feature-hub.ts
@@ -103,7 +103,8 @@ export function createFeatureHub(
   if (featureServiceDefinitions) {
     featureServiceRegistry.registerFeatureServices(
       featureServiceDefinitions,
-      integratorId
+      integratorId,
+      false
     );
   }
 

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -308,7 +308,8 @@ export class FeatureAppManager {
     if (featureAppDefinition.ownFeatureServiceDefinitions) {
       this.featureServiceRegistry.registerFeatureServices(
         featureAppDefinition.ownFeatureServiceDefinitions,
-        featureAppId
+        featureAppId,
+        true
       );
     }
 


### PR DESCRIPTION
- recover from missing or broken feature service when starting featurehub.