### PR TITLE
fix(demos): avoid optional chaining operator

### DIFF
--- a/packages/demos/src/start-server.js
+++ b/packages/demos/src/start-server.js
@@ -84,7 +84,9 @@ async function startServer(
     nodeIntegratorWebpackConfig && webpack(nodeIntegratorWebpackConfig);
 
   const nodeIntegratorFilename =
-    nodeIntegratorCompiler?.options.output?.filename;
+    nodeIntegratorCompiler &&
+    nodeIntegratorCompiler.options.output &&
+    nodeIntegratorCompiler.options.output.filename;
 
   if (nodeIntegratorCompiler) {
     app.use(devMiddleware(nodeIntegratorCompiler, {serverSideRender: true}));


### PR DESCRIPTION
Optional chaining is not supported in Node 12.
