### PR TITLE
Module federation loader JSDoc comments

### DIFF
--- a/packages/core/src/create-feature-hub.ts
+++ b/packages/core/src/create-feature-hub.ts
@@ -51,10 +51,11 @@ export interface FeatureHubOptions {
   readonly providedExternals?: ProvidedExternals;
 
   /**
-   * For the [[FeatureAppManager]] to be able to load Feature Apps from a
-   * remote location, a module loader must be provided, (e.g. the
-   * `@feature-hub/module-loader-amd` package or the
-   * `@feature-hub/module-loader-commonjs` package).
+   * For the `FeatureAppManager` to be able to load Feature Apps from a remote
+   * location, a module loader must be provided. This can either be one of the
+   * module loaders that are provided by @feature-hub, i.e.
+   * `@feature-hub/module-loader-amd`, `@feature-hub/module-loader-federation`,
+   * and `@feature-hub/module-loader-commonjs`, or a custom loader.
    */
   readonly moduleLoader?: ModuleLoader;
 

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -61,6 +61,14 @@ export interface FeatureAppDefinition<
   create(env: FeatureAppEnvironment<TFeatureServices, TConfig>): TFeatureApp;
 }
 
+/**
+ * @param url A URL pointing to a [[FeatureAppDefinition]] bundle in a module
+ * format compatible with the module loader.
+ *
+ * @param moduleType The module type of the [[FeatureAppDefinition]] bundle.
+ * This can be used to choose different loading strategies based on the module
+ * type of the Feature App.
+ */
 export type ModuleLoader = (
   url: string,
   moduleType?: string
@@ -117,9 +125,10 @@ export interface FeatureAppScopeOptions<
 export interface FeatureAppManagerOptions {
   /**
    * For the `FeatureAppManager` to be able to load Feature Apps from a remote
-   * location, a module loader must be provided, (e.g. the
-   * `@feature-hub/module-loader-amd` package or the
-   * `@feature-hub/module-loader-commonjs` package).
+   * location, a module loader must be provided. This can either be one of the
+   * module loaders that are provided by @feature-hub, i.e.
+   * `@feature-hub/module-loader-amd`, `@feature-hub/module-loader-federation`,
+   * and `@feature-hub/module-loader-commonjs`, or a custom loader.
    */
   readonly moduleLoader?: ModuleLoader;
 
@@ -180,14 +189,18 @@ export class FeatureAppManager {
    *
    * @throws Throws an error if no module loader was provided on initilization.
    *
-   * @param url A URL pointing to a [[FeatureAppDefinition]] bundle in a
-   * module format compatible with the module loader.
+   * @param url A URL pointing to a [[FeatureAppDefinition]] bundle in a module
+   * format compatible with the module loader.
+   *
+   * @param moduleType The module type of the [[FeatureAppDefinition]] bundle.
+   * This value can be used by the provided
+   * [[FeatureAppManagerOptions.moduleLoader]].
    *
    * @returns An [[AsyncValue]] containing a promise that resolves with the
    * loaded [[FeatureAppDefinition]]. If called again with the same URL it
-   * returns the same [[AsyncValue]]. The promise rejects when loading
-   * fails, or when the loaded bundle doesn't export a [[FeatureAppDefinition]]
-   * as default.
+   * returns the same [[AsyncValue]]. The promise rejects when loading fails, or
+   * when the loaded bundle doesn't export a [[FeatureAppDefinition]] as
+   * default.
    */
   public getAsyncFeatureAppDefinition(
     url: string,
@@ -277,7 +290,12 @@ export class FeatureAppManager {
    *
    * @throws Throws an error if no module loader was provided on initilization.
    *
-   * @see [[getAsyncFeatureAppDefinition]] for further information.
+   * @param url A URL pointing to a [[FeatureAppDefinition]] bundle in a module
+   * format compatible with the module loader.
+   *
+   * @param moduleType The module type of the [[FeatureAppDefinition]] bundle.
+   * This value can be used by the provided
+   * [[FeatureAppManagerOptions.moduleLoader]].
    */
   public async preloadFeatureApp(
     url: string,

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -44,6 +44,11 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    */
   readonly src: string;
 
+  /**
+   * The module type of the Feature App's client module bundle. It is passed to
+   * the module loader that was provided as part of
+   * [[FeatureAppManagerOptions.moduleLoader]].
+   */
   readonly moduleType?: string;
 
   /**
@@ -53,6 +58,11 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    */
   readonly serverSrc?: string;
 
+  /**
+   * The module type of the Feature App's server module bundle. It is passed to
+   * the module loader that was provided as part of
+   * [[FeatureAppManagerOptions.moduleLoader]].
+   */
   readonly serverModuleType?: string;
 
   /**

--- a/packages/react/src/feature-hub-context.tsx
+++ b/packages/react/src/feature-hub-context.tsx
@@ -29,12 +29,17 @@ export interface FeatureHubContextProviderValue {
 
   /**
    * A callback that the integrator provides on the server, mainly for the
-   * [[FeatureAppLoader]], to add client URLs of those Feature Apps that
-   * are rendered on the server, so that they can be preloaded on the client
-   * before hydration. Calling it more than once with the same URL must not have
-   * any impact.
+   * [[FeatureAppLoader]], to add client URLs of those Feature Apps that are
+   * rendered on the server, so that they can be preloaded on the client before
+   * hydration. This method might be called multiple times with the same URL
+   * during server-side rendering. Therefore deduplication should be considered.
    *
-   * @param url The client URL of a Feature App that is rendered on the server.
+   * @param url The **client** URL of a Feature App that is rendered on the
+   * server.
+   *
+   * @param moduleType The **client** module type of the Feature App that is
+   * rendered on the server. This value can be used by the provided
+   * [[FeatureAppManagerOptions.moduleLoader]].
    */
   addUrlForHydration?(url: string, moduleType?: string): void;
 
@@ -42,8 +47,9 @@ export interface FeatureHubContextProviderValue {
    * A callback that the integrator provides on the server, mainly for the
    * [[FeatureAppLoader]], to add stylesheets for those Feature Apps that are
    * rendered on the server, so that they can be added to the document before
-   * being sent to the client. Calling it more than once with the same `href`
-   * must not have any impact.
+   * being sent to the client. This method might be called multiple times with
+   * the same list of stylesheets (per Feature App) during server-side
+   * rendering. Therefore deduplication should be considered.
    *
    * @param stylesheets A list of stylesheets for a Feature App that is rendered
    * on the server.


### PR DESCRIPTION
- docs(core): add JSDoc comments for the new `moduleType` param
- docs(react): add JSDoc comments for the new `moduleType` param
