### PR TITLE
feat(all): add failure option to done call

### DIFF
--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -45,8 +45,11 @@ export interface FeatureAppEnvironment<
    * If this callback is defined, a short-lived Feature App can call this
    * function when it has completed its task. The Integrator (or parent Feature
    * App) can then decide to e.g. unmount the Feature App.
+   *
+   * By default it is assumed that the FA exited successfully, but it can signal
+   * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: () => void;
+  readonly done?: (failed?: boolean) => void;
 }
 
 export interface FeatureAppDefinition<
@@ -118,8 +121,11 @@ export interface FeatureAppScopeOptions<
    * short-lived Feature App can call this function when it has completed its
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
+   *
+   * By default it is assumed that the FA exited successfully, but it can signal
+   * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: () => void;
+  readonly done?: (failed?: boolean) => void;
 }
 
 export interface FeatureAppManagerOptions {

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -49,7 +49,7 @@ export interface FeatureAppEnvironment<
    * By default it is assumed that the FA exited successfully, but it can signal
    * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: (failed?: boolean) => void;
+  readonly done?: (result?: unknown) => void;
 }
 
 export interface FeatureAppDefinition<
@@ -125,7 +125,7 @@ export interface FeatureAppScopeOptions<
    * By default it is assumed that the FA exited successfully, but it can signal
    * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: (failed?: boolean) => void;
+  readonly done?: (result?: unknown) => void;
 }
 
 export interface FeatureAppManagerOptions {

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -46,8 +46,10 @@ export interface FeatureAppEnvironment<
    * function when it has completed its task. The Integrator (or parent Feature
    * App) can then decide to e.g. unmount the Feature App.
    *
-   * By default it is assumed that the FA exited successfully, but it can signal
-   * that it failed. It is up to the integrator to handle this.
+   * Optionally, the Feature App can pass a result
+   * into the done callback. The type/structure of
+   * the result must be agreed between the Integrator
+   * (or parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 }
@@ -122,8 +124,10 @@ export interface FeatureAppScopeOptions<
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * By default it is assumed that the FA exited successfully, but it can signal
-   * that it failed. It is up to the integrator to handle this.
+   * Optionally, the Feature App can pass a result
+   * into the done callback. The type/structure of
+   * the result must be agreed between the Integrator
+   * (or parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 }

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -46,10 +46,9 @@ export interface FeatureAppEnvironment<
    * function when it has completed its task. The Integrator (or parent Feature
    * App) can then decide to e.g. unmount the Feature App.
    *
-   * Optionally, the Feature App can pass a result
-   * into the done callback. The type/structure of
-   * the result must be agreed between the Integrator
-   * (or parent Feature App) and the Feature App.
+   * Optionally, the Feature App can pass a result into the done callback. The
+   * type/structure of the result must be agreed between the Integrator (or
+   * parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 }
@@ -124,10 +123,9 @@ export interface FeatureAppScopeOptions<
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * Optionally, the Feature App can pass a result
-   * into the done callback. The type/structure of
-   * the result must be agreed between the Integrator
-   * (or parent Feature App) and the Feature App.
+   * Optionally, the Feature App can pass a result into the done callback. The
+   * type/structure of the result must be agreed between the Integrator (or
+   * parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 }

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -89,10 +89,9 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * Optionally, the Feature App can pass a result
-   * into the done callback. The type/structure of
-   * the result must be agreed between the Integrator
-   * (or parent Feature App) and the Feature App.
+   * Optionally, the Feature App can pass a result into the done callback. The
+   * type/structure of the result must be agreed between the Integrator (or
+   * parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -92,7 +92,7 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    * By default it is assumed that the FA exited successfully, but it can signal
    * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: (failed?: boolean) => void;
+  readonly done?: (result?: unknown) => void;
 
   readonly onError?: (error: Error) => void;
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -88,8 +88,11 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    * short-lived Feature App can call this function when it has completed its
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
+   *
+   * By default it is assumed that the FA exited successfully, but it can signal
+   * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: () => void;
+  readonly done?: (failed?: boolean) => void;
 
   readonly onError?: (error: Error) => void;
 

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -89,8 +89,10 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * By default it is assumed that the FA exited successfully, but it can signal
-   * that it failed. It is up to the integrator to handle this.
+   * Optionally, the Feature App can pass a result
+   * into the done callback. The type/structure of
+   * the result must be agreed between the Integrator
+   * (or parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -76,8 +76,11 @@ export interface BaseFeatureAppContainerProps<
    * short-lived Feature App can call this function when it has completed its
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
+   *
+   * By default it is assumed that the FA exited successfully, but it can signal
+   * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: () => void;
+  readonly done?: (failed?: boolean) => void;
 
   readonly onError?: (error: Error) => void;
 

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -80,7 +80,7 @@ export interface BaseFeatureAppContainerProps<
    * By default it is assumed that the FA exited successfully, but it can signal
    * that it failed. It is up to the integrator to handle this.
    */
-  readonly done?: (failed?: boolean) => void;
+  readonly done?: (result?: unknown) => void;
 
   readonly onError?: (error: Error) => void;
 

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -77,10 +77,9 @@ export interface BaseFeatureAppContainerProps<
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * Optionally, the Feature App can pass a result
-   * into the done callback. The type/structure of
-   * the result must be agreed between the Integrator
-   * (or parent Feature App) and the Feature App.
+   * Optionally, the Feature App can pass a result into the done callback. The
+   * type/structure of the result must be agreed between the Integrator (or
+   * parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -77,8 +77,10 @@ export interface BaseFeatureAppContainerProps<
    * task. The Integrator (or parent Feature App) can then decide to e.g.
    * unmount the Feature App.
    *
-   * By default it is assumed that the FA exited successfully, but it can signal
-   * that it failed. It is up to the integrator to handle this.
+   * Optionally, the Feature App can pass a result
+   * into the done callback. The type/structure of
+   * the result must be agreed between the Integrator
+   * (or parent Feature App) and the Feature App.
    */
   readonly done?: (result?: unknown) => void;
 


### PR DESCRIPTION
With this a feature app can include some other FA to select
something and the new FA can signal in the done call if
changes should be applied or if it just terminated and
nothing should be changed