### PR TITLE
Enable async render inside renderUntilCompleted

### DIFF
--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -74,6 +74,22 @@ describe('defineAsyncSsrManager', () => {
           expect(html).toEqual('testHtml');
           expect(mockRender).toHaveBeenCalledTimes(1);
         });
+
+        describe('when the given render function returns a promise', () => {
+          it('resolves with the html string that is resolved from the render function', async () => {
+            const asyncSsrManager = asyncSsrManagerBinder('test')
+              .featureService;
+
+            const mockRender = jest.fn(async () => 'testHtml');
+
+            const html = await useFakeTimers(async () =>
+              asyncSsrManager.renderUntilCompleted(mockRender)
+            );
+
+            expect(html).toEqual('testHtml');
+            expect(mockRender).toHaveBeenCalledTimes(1);
+          });
+        });
       });
 
       describe('with an integrator, and a consumer that schedules a rerender with a custom promise', () => {

--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -37,7 +37,7 @@ export interface AsyncSsrManagerV1 {
    *
    * @param render A render function that is called for each render pass.
    */
-  renderUntilCompleted(render: () => string): Promise<string>;
+  renderUntilCompleted(render: () => Promise<string> | string): Promise<string>;
 
   /**
    * This method is intended for consumers, i.e. Feature Apps and Feature

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -16,7 +16,9 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     private readonly timeout?: number
   ) {}
 
-  public async renderUntilCompleted(render: () => string): Promise<string> {
+  public async renderUntilCompleted(
+    render: () => Promise<string> | string
+  ): Promise<string> {
     const renderPromise = this.renderingLoop(render);
 
     if (typeof this.timeout !== 'number') {
@@ -36,8 +38,10 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     this.asyncOperations.add(asyncOperation);
   }
 
-  private async renderingLoop(render: () => string): Promise<string> {
-    let html = render();
+  private async renderingLoop(
+    render: () => Promise<string> | string
+  ): Promise<string> {
+    let html = await render();
 
     while (this.asyncOperations.size > 0) {
       while (this.asyncOperations.size > 0) {
@@ -54,7 +58,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
         await Promise.all(asyncOperationsSnapshot);
       }
 
-      html = render();
+      html = await render();
     }
 
     return html;


### PR DESCRIPTION
We have discovered at the team that asynchronous rendering is necessary for things like https://www.apollographql.com/docs/react/api/react/ssr/#rendertostringwithdata. Therefore we have introduced support of asynchronous rendering to the `renderUntilCompleted`.

Example code:
```typescript
import { renderToStringWithData } from '@apollo/client/react/ssr';

//...

const content = await asyncSsrManager.renderUntilCompleted(() =>
  renderToStringWithData(
    <React.StrictMode>
      <ApolloProvider client={client}>
        <StyleSheetManager sheet={sheet.instance}>
          <FeatureHubContextProvider value={featureHubContextValue}>
            <App />
          </FeatureHubContextProvider>
        </StyleSheetManager>
      </ApolloProvider>
    </React.StrictMode>
  )
);

const serializedStates = serializedStateManager.serializeStates();
const html = (
  <Html
    content={content}
    hydrationSources={hydrationSources}
    serializedStates={serializedStates}
    styles={sheet.getStyleElement()}
    state={client.extract()}
  />
);
```
`renderToStringWithData` returns `Promise<string>`. Reimplementing the state extraction done within `renderToStringWithData` doesn't seem like a graceful approach. Apparently, the `renderUntilCompleted` is already asynchronous, so we decided to expand its capabilities towards async rendering.