### PR TITLE
fix(react): remove deprecated `renderError` prop

### DIFF
--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -295,71 +295,6 @@ describe('FeatureAppContainer', () => {
         });
       });
 
-      describe('with no renderError and no children function provided', () => {
-        it('renders null', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBeNull();
-        });
-      });
-
-      describe('with a renderError function provided', () => {
-        it('calls the function with the error', () => {
-          const renderError = jest.fn().mockReturnValue(null);
-
-          renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={renderError}
-            />
-          );
-
-          expect(renderError.mock.calls).toEqual([[mockError]]);
-        });
-
-        it('renders what the function returns', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={() => 'Custom Error UI'}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBe('Custom Error UI');
-        });
-
-        describe('when renderError throws an error', () => {
-          let renderErrorMockError: Error;
-
-          beforeEach(() => {
-            renderErrorMockError = new Error('Throwing in renderError.');
-          });
-
-          it('re-throws the error', () => {
-            expect(() =>
-              renderWithFeatureHubContext(
-                <FeatureAppContainer
-                  featureAppId="testId"
-                  featureAppDefinition={mockFeatureAppDefinition}
-                  renderError={() => {
-                    throw renderErrorMockError;
-                  }}
-                />
-              )
-            ).toThrowError(renderErrorMockError);
-
-            expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
-          });
-        });
-      });
-
       describe('with a children function provided', () => {
         it('calls the children function with the error and loading=false', () => {
           const children = jest.fn(
@@ -538,50 +473,6 @@ describe('FeatureAppContainer', () => {
               ...noErrorBoundaryConsoleErrorCalls,
             ]);
           });
-        });
-      });
-
-      describe('with no renderError function provided', () => {
-        it('renders null', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBeNull();
-          expectConsoleErrorCalls(usingErrorBoundaryConsoleErrorCalls);
-        });
-      });
-
-      describe('with a renderError function provided', () => {
-        it('calls the function with the error', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={() => 'Custom Error UI'}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBe('Custom Error UI');
-          expectConsoleErrorCalls(usingErrorBoundaryConsoleErrorCalls);
-        });
-
-        it('renders what the function returns', () => {
-          const renderError = jest.fn().mockReturnValue(null);
-
-          renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={renderError}
-            />
-          );
-
-          expect(renderError.mock.calls).toEqual([[mockError]]);
-          expectConsoleErrorCalls(usingErrorBoundaryConsoleErrorCalls);
         });
       });
     });
@@ -890,59 +781,6 @@ describe('FeatureAppContainer', () => {
                   ]);
                 });
               });
-            });
-          });
-
-          describe('without renderError provided', () => {
-            it('renders null after rejection ', async () => {
-              const testRenderer = renderWithFeatureHubContext(
-                <FeatureAppContainer
-                  featureAppId="testId"
-                  featureAppDefinition={mockFeatureAppDefinition}
-                />
-              );
-
-              expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
-                <div>
-                  This is the React Feature App with a loading promise.
-                </div>
-              `);
-
-              await rejectLoadingPromise(loadingPromiseMockError);
-
-              expect(testRenderer.toJSON()).toBe(null);
-            });
-          });
-
-          describe('with renderError provided', () => {
-            it('renders renderError result after rejection', async () => {
-              const renderError = jest.fn(() => <span>custom Error UI</span>);
-
-              const testRenderer = renderWithFeatureHubContext(
-                <FeatureAppContainer
-                  featureAppId="testId"
-                  featureAppDefinition={mockFeatureAppDefinition}
-                  renderError={renderError}
-                />
-              );
-
-              expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
-                <div>
-                  This is the React Feature App with a loading promise.
-                </div>
-              `);
-
-              await rejectLoadingPromise(loadingPromiseMockError);
-
-              expect(renderError).toHaveBeenLastCalledWith(
-                loadingPromiseMockError
-              );
-
-              expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
-                <span>
-                  custom Error UI
-                </span>
-              `);
             });
           });
         });
@@ -1282,38 +1120,6 @@ describe('FeatureAppContainer', () => {
         });
       });
 
-      describe('with a renderError function provided', () => {
-        it('calls the function with the error', () => {
-          const renderError = jest.fn().mockReturnValue(null);
-
-          renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={renderError}
-            />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
-          );
-
-          expect(renderError.mock.calls).toEqual([[mockError]]);
-        });
-
-        it('renders the result of the function', () => {
-          const customErrorUI = 'custom error UI';
-
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppContainer
-              featureAppId="testId"
-              featureAppDefinition={mockFeatureAppDefinition}
-              renderError={() => customErrorUI}
-            />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
-          );
-
-          expect(testRenderer.toJSON()).toBe(customErrorUI);
-        });
-      });
-
       describe('with a children function provided', () => {
         it('calls the function with the error', () => {
           const children = jest.fn(
@@ -1359,7 +1165,7 @@ describe('FeatureAppContainer', () => {
         });
       });
 
-      describe('without a renderError or children function provided', () => {
+      describe('without a children function provided', () => {
         it('renders null', () => {
           const testRenderer = renderWithFeatureHubContext(
             <FeatureAppContainer
@@ -1530,73 +1336,6 @@ describe('FeatureAppContainer', () => {
 
           expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
         });
-      });
-    });
-
-    describe('with a renderError function provided', () => {
-      it('calls the function with the creation error', () => {
-        const renderError = jest.fn().mockReturnValue(null);
-
-        renderWithFeatureHubContext(
-          <FeatureAppContainer
-            featureAppId="testId"
-            featureAppDefinition={mockFeatureAppDefinition}
-            renderError={renderError}
-          />
-        );
-
-        expect(renderError.mock.calls).toEqual([[mockError]]);
-      });
-
-      it('renders the result of the function', () => {
-        const customErrorUI = 'custom error UI';
-
-        const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppContainer
-            featureAppId="testId"
-            featureAppDefinition={mockFeatureAppDefinition}
-            renderError={() => customErrorUI}
-          />
-        );
-
-        expect(testRenderer.toJSON()).toBe(customErrorUI);
-      });
-
-      describe('when renderError throws an error', () => {
-        let renderErrorMockError: Error;
-
-        beforeEach(() => {
-          renderErrorMockError = new Error('Throwing in renderError.');
-        });
-
-        it('re-throws the error', () => {
-          expect(() =>
-            renderWithFeatureHubContext(
-              <FeatureAppContainer
-                featureAppId="testId"
-                featureAppDefinition={mockFeatureAppDefinition}
-                renderError={() => {
-                  throw renderErrorMockError;
-                }}
-              />
-            )
-          ).toThrowError(renderErrorMockError);
-
-          expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
-        });
-      });
-    });
-
-    describe('without a renderError function provided', () => {
-      it('renders null', () => {
-        const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppContainer
-            featureAppId="testId"
-            featureAppDefinition={mockFeatureAppDefinition}
-          />
-        );
-
-        expect(testRenderer.toJSON()).toBeNull();
       });
     });
 

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -311,7 +311,6 @@ describe('FeatureAppLoader', () => {
 
     it('renders an InternalFeatureAppContainer', () => {
       const onError = jest.fn();
-      const renderError = jest.fn();
       const beforeCreate = jest.fn();
       const done = jest.fn();
       const children = jest.fn();
@@ -324,7 +323,6 @@ describe('FeatureAppLoader', () => {
           beforeCreate={beforeCreate}
           done={done}
           onError={onError}
-          renderError={renderError}
           baseUrl="/base"
           children={children}
         />
@@ -340,7 +338,6 @@ describe('FeatureAppLoader', () => {
         featureAppDefinition: mockFeatureAppDefinition,
         featureAppId: 'testId',
         onError,
-        renderError,
         children,
         featureAppManager: mockFeatureAppManager,
         logger,
@@ -466,121 +463,6 @@ describe('FeatureAppLoader', () => {
       });
     });
 
-    describe('with a renderError function provided', () => {
-      it('calls the function with the error', () => {
-        const renderError = jest.fn().mockReturnValue(null);
-
-        renderWithFeatureHubContext(
-          <FeatureAppLoader
-            featureAppId="testId"
-            src="example.js"
-            renderError={renderError}
-          />
-        );
-
-        expect(renderError.mock.calls).toEqual([[mockError]]);
-      });
-
-      it('renders what the function returns', () => {
-        const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader
-            featureAppId="testId"
-            src="example.js"
-            renderError={() => 'Custom Error UI'}
-          />
-        );
-
-        expect(testRenderer.toJSON()).toBe('Custom Error UI');
-      });
-
-      describe('when renderError throws an error', () => {
-        let renderErrorMockError: Error;
-
-        beforeEach(() => {
-          renderErrorMockError = new Error('Throwing in renderError.');
-        });
-
-        it('throws the error in render', () => {
-          const handleError = jest.fn();
-
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              renderError={() => {
-                throw renderErrorMockError;
-              }}
-            />,
-            {handleError}
-          );
-
-          expect(handleError.mock.calls).toEqual([[renderErrorMockError]]);
-          expect(testRenderer.toJSON()).toBe('test error boundary');
-          expectConsoleErrorCalls(usingTestErrorBoundaryConsoleErrorCalls);
-        });
-      });
-
-      describe('when onError is also provided', () => {
-        it('calls onError with the error', () => {
-          const onError = jest.fn();
-
-          renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              onError={onError}
-              renderError={jest.fn().mockReturnValue(null)}
-            />
-          );
-
-          expect(onError.mock.calls).toEqual([[mockError]]);
-        });
-
-        it('renders what the renderError function returns', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              onError={jest.fn()}
-              renderError={() => 'Custom Error UI'}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBe('Custom Error UI');
-        });
-
-        describe('and throws an error', () => {
-          let onErrorMockError: Error;
-
-          beforeEach(() => {
-            onErrorMockError = new Error('Throwing in onError.');
-          });
-
-          it('does not call renderError and throws the error in render', () => {
-            const handleError = jest.fn();
-            const renderError = jest.fn();
-
-            const testRenderer = renderWithFeatureHubContext(
-              <FeatureAppLoader
-                featureAppId="testId"
-                src="example.js"
-                onError={() => {
-                  throw onErrorMockError;
-                }}
-                renderError={renderError}
-              />,
-              {handleError}
-            );
-
-            expect(renderError).not.toHaveBeenCalled();
-            expect(handleError.mock.calls).toEqual([[onErrorMockError]]);
-            expect(testRenderer.toJSON()).toBe('test error boundary');
-            expectConsoleErrorCalls(usingTestErrorBoundaryConsoleErrorCalls);
-          });
-        });
-      });
-    });
-
     describe('with children function provided', () => {
       it('calls children with error and loading=false', () => {
         const children = jest.fn().mockReturnValue(null);
@@ -643,27 +525,6 @@ describe('FeatureAppLoader', () => {
         });
       });
 
-      describe('when (deprecated) renderError is also provided', () => {
-        it('favours children over renderError', () => {
-          const children = jest.fn(() => 'Custom Error UI via children');
-          const renderError = jest.fn(() => 'Custom Error UI via renderError');
-
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              children={children}
-              renderError={renderError}
-            />
-          );
-
-          expect(children).toHaveBeenCalled();
-          expect(renderError).not.toHaveBeenCalled();
-
-          expect(testRenderer.toJSON()).toBe('Custom Error UI via children');
-        });
-      });
-
       describe('when onError is also provided', () => {
         it('calls onError with the error', () => {
           const onError = jest.fn();
@@ -678,19 +539,6 @@ describe('FeatureAppLoader', () => {
           );
 
           expect(onError.mock.calls).toEqual([[mockError]]);
-        });
-
-        it('renders what the renderError function returns', () => {
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              onError={jest.fn()}
-              children={() => 'Custom Error UI'}
-            />
-          );
-
-          expect(testRenderer.toJSON()).toBe('Custom Error UI');
         });
 
         describe('and throws an error', () => {
@@ -1004,73 +852,6 @@ describe('FeatureAppLoader', () => {
 
             expect(testRenderer.toJSON()).toBeNull();
           });
-        });
-      });
-    });
-
-    describe('with a renderError function provided', () => {
-      it('calls the function with the error', async () => {
-        const renderError = jest.fn().mockReturnValue(null);
-
-        renderWithFeatureHubContext(
-          <FeatureAppLoader
-            featureAppId="testId"
-            src="example.js"
-            renderError={renderError}
-          />
-        );
-
-        try {
-          await mockAsyncFeatureAppDefinition.promise;
-        } catch (error) {}
-
-        expect(renderError.mock.calls).toEqual([[mockError]]);
-      });
-
-      it('renders what the function returns', async () => {
-        const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader
-            featureAppId="testId"
-            src="example.js"
-            renderError={() => 'Custom Error UI'}
-          />
-        );
-
-        try {
-          await mockAsyncFeatureAppDefinition.promise;
-        } catch (error) {}
-
-        expect(testRenderer.toJSON()).toBe('Custom Error UI');
-      });
-
-      describe('when renderError throws an error', () => {
-        let renderErrorMockError: Error;
-
-        beforeEach(() => {
-          renderErrorMockError = new Error('Throwing in renderError.');
-        });
-
-        it('throws the error in render', async () => {
-          const handleError = jest.fn();
-
-          const testRenderer = renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              renderError={() => {
-                throw renderErrorMockError;
-              }}
-            />,
-            {handleError}
-          );
-
-          try {
-            await mockAsyncFeatureAppDefinition.promise;
-          } catch (error) {}
-
-          expect(handleError.mock.calls).toEqual([[renderErrorMockError]]);
-          expect(testRenderer.toJSON()).toBe('test error boundary');
-          expectConsoleErrorCalls(usingTestErrorBoundaryConsoleErrorCalls);
         });
       });
     });

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -98,11 +98,6 @@ export interface FeatureAppLoaderProps<TConfig = unknown> {
   readonly onError?: (error: unknown) => void;
 
   /**
-   * @deprecated Use the `children` render function instead to render an error.
-   */
-  readonly renderError?: (error: unknown) => React.ReactNode;
-
-  /**
    * A children function can be provided to customize rendering of the
    * Feature App and provide Error or Loading UIs.
    */
@@ -239,8 +234,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       featureAppId,
       featureAppName,
       onError,
-      // tslint:disable-next-line: deprecation
-      renderError,
       done,
       featureAppManager,
       logger,
@@ -255,10 +248,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
 
       if (children) {
         return children({error, loading: false});
-      }
-
-      if (renderError) {
-        return renderError(error);
       }
 
       return null;
@@ -280,7 +269,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
           featureAppDefinition as FeatureAppDefinition<FeatureApp>
         }
         onError={onError}
-        renderError={renderError}
         done={done}
         featureAppManager={featureAppManager}
         logger={logger}

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -86,11 +86,6 @@ export interface BaseFeatureAppContainerProps<
   readonly onError?: (error: unknown) => void;
 
   /**
-   * @deprecated Use the `children` render function instead to render an error.
-   */
-  readonly renderError?: (error: unknown) => React.ReactNode;
-
-  /**
    * A children function can be provided to customize rendering of the
    * Feature App and provide Error or Loading UIs.
    */
@@ -291,18 +286,9 @@ export class InternalFeatureAppContainer<
   }
 
   private renderError(error: unknown): React.ReactNode {
-    // tslint:disable-next-line: deprecation
-    const {children, renderError} = this.props;
+    const {children} = this.props;
 
-    if (children) {
-      return children({error, loading: false});
-    }
-
-    if (renderError) {
-      return renderError(error);
-    }
-
-    return null;
+    return children ? children({error, loading: false}) : null;
   }
 
   private handleError(error: unknown): void {


### PR DESCRIPTION
BREAKING CHANGE: Removed `renderError` prop. Use the `children` prop instead.