### PR TITLE
style(all): set prettier config `trailingComma` to `all`

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,7 @@ const {readdirSync} = require('fs');
 const path = require('path');
 
 const pkgScopes = readdirSync(path.join(__dirname, 'packages')).filter(
-  (scope) => !/^\./.test(scope)
+  (scope) => !/^\./.test(scope),
 );
 
 const scopes = ['all', ...pkgScopes];

--- a/docs/guides/custom-logging.md
+++ b/docs/guides/custom-logging.md
@@ -85,7 +85,7 @@ const {featureAppManager} = createFeatureHub('acme:integrator', {
   logger,
   featureServiceDefinitions: [
     defineLogger((consumerId, consumerName) =>
-      logger.child({consumerId, consumerName})
+      logger.child({consumerId, consumerName}),
     ),
   ],
 });

--- a/docs/guides/integrating-the-feature-hub.md
+++ b/docs/guides/integrating-the-feature-hub.md
@@ -38,7 +38,7 @@ const {featureAppManager, featureServiceRegistry} = createFeatureHub(
       someFeatureServiceDefinition1,
       someFeatureServiceDefinition2,
     ],
-  }
+  },
 );
 ```
 
@@ -849,7 +849,7 @@ mainFeatureAppContainer.featureAppDefinition = someFeatureAppDefinition;
 document.querySelector('main').appendChild(mainFeatureAppContainer);
 
 const asideFeatureAppContainer = document.createElement(
-  'feature-app-container'
+  'feature-app-container',
 );
 
 asideFeatureAppContainer.setAttribute('featureAppId', 'some-feature-app:aside');
@@ -871,7 +871,7 @@ featureAppContainer.featureAppDefinition = someFeatureAppDefinition;
 
 featureAppContainer.setAttribute(
   'baseUrl',
-  'https://example.com/some-feature-app'
+  'https://example.com/some-feature-app',
 );
 
 document.querySelector('#app').appendChild(featureAppContainer);
@@ -912,7 +912,7 @@ mainFeatureAppContainer.featureAppDefinition = someFeatureAppDefinition;
 document.querySelector('main').appendChild(mainFeatureAppContainer);
 
 const asideFeatureAppContainer = document.createElement(
-  'feature-app-container'
+  'feature-app-container',
 );
 
 asideFeatureAppContainer.setAttribute('featureAppId', 'some-feature-app:aside');

--- a/docs/guides/server-side-rendering.md
+++ b/docs/guides/server-side-rendering.md
@@ -123,7 +123,7 @@ element][demos-extract-hydration-urls-script], and then preloaded using the
 const urlsForHydration = getUrlsForHydrationFromDom();
 
 await Promise.all(
-  urlsForHydration.map(async (url) => featureAppManager.preloadFeatureApp(url))
+  urlsForHydration.map(async (url) => featureAppManager.preloadFeatureApp(url)),
 );
 ```
 
@@ -166,8 +166,8 @@ const hydrationSources = getHydrationSourcesFromDom();
 
 await Promise.all(
   hydrationSources.map(async ({url, moduleType}) =>
-    featureAppManager.preloadFeatureApp(url, moduleType)
-  )
+    featureAppManager.preloadFeatureApp(url, moduleType),
+  ),
 );
 ```
 
@@ -340,8 +340,8 @@ const html = await asyncSsrManager.renderUntilCompleted(() =>
         src="https://example.com/some-feature-app.js"
         serverSrc="https://example.com/some-feature-app-node.js"
       />
-    </FeatureHubContextProvider>
-  )
+    </FeatureHubContextProvider>,
+  ),
 );
 ```
 

--- a/docs/guides/writing-a-feature-service.md
+++ b/docs/guides/writing-a-feature-service.md
@@ -290,7 +290,7 @@ const myFeatureServiceDefinition = {
         getTotalCount() {
           return Object.values(consumerCounts).reduce(
             (totalCount, consumerCount) => totalCount + consumerCount,
-            0
+            0,
           );
         },
       };

--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -68,7 +68,7 @@ describe('defineAsyncSsrManager', () => {
           const mockRender = jest.fn(() => 'testHtml');
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManager.renderUntilCompleted(mockRender)
+            asyncSsrManager.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('testHtml');
@@ -83,7 +83,7 @@ describe('defineAsyncSsrManager', () => {
             const mockRender = jest.fn(async () => 'testHtml');
 
             const html = await useFakeTimers(async () =>
-              asyncSsrManager.renderUntilCompleted(mockRender)
+              asyncSsrManager.renderUntilCompleted(mockRender),
             );
 
             expect(html).toEqual('testHtml');
@@ -95,7 +95,7 @@ describe('defineAsyncSsrManager', () => {
       describe('with an integrator, and a consumer that schedules a rerender with a custom promise', () => {
         it('resolves with an html string after the second render pass', async () => {
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
-            'test:integrator'
+            'test:integrator',
           ).featureService;
 
           const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
@@ -114,7 +114,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender)
+            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('render pass 2');
@@ -125,7 +125,7 @@ describe('defineAsyncSsrManager', () => {
       describe('with an integrator, and a consumer that schedules a rerender without a custom promise', () => {
         it('resolves with an html string after the second render pass', async () => {
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
-            'test:integrator'
+            'test:integrator',
           ).featureService;
 
           const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
@@ -144,7 +144,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender)
+            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('render pass 2');
@@ -155,7 +155,7 @@ describe('defineAsyncSsrManager', () => {
       describe('with an integrator, and a consumer that schedules a rerender in two consecutive render passes', () => {
         it('resolves with an html string after the third render pass', async () => {
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
-            'test:integrator'
+            'test:integrator',
           ).featureService;
 
           const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
@@ -174,7 +174,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender)
+            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('render pass 3');
@@ -187,7 +187,7 @@ describe('defineAsyncSsrManager', () => {
           expect.assertions(2);
 
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
-            'test:integrator'
+            'test:integrator',
           ).featureService;
 
           const asyncSsrManagerConsumer = asyncSsrManagerBinder('test:consumer')
@@ -213,7 +213,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender)
+            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('render pass 2, consumer result 2');
@@ -224,15 +224,15 @@ describe('defineAsyncSsrManager', () => {
       describe('with an integrator, and two consumers that both schedule a rerender in the first render pass', () => {
         it('resolves with an html string after the second render pass', async () => {
           const asyncSsrManagerIntegrator = asyncSsrManagerBinder(
-            'test:integrator'
+            'test:integrator',
           ).featureService;
 
           const asyncSsrManagerConsumer1 = asyncSsrManagerBinder(
-            'test:consumer:1'
+            'test:consumer:1',
           ).featureService;
 
           const asyncSsrManagerConsumer2 = asyncSsrManagerBinder(
-            'test:consumer:2'
+            'test:consumer:2',
           ).featureService;
 
           let renderPass = 0;
@@ -249,7 +249,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           const html = await useFakeTimers(async () =>
-            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender)
+            asyncSsrManagerIntegrator.renderUntilCompleted(mockRender),
           );
 
           expect(html).toEqual('render pass 2');
@@ -267,7 +267,7 @@ describe('defineAsyncSsrManager', () => {
           });
 
           return expect(
-            asyncSsrManager.renderUntilCompleted(mockRender)
+            asyncSsrManager.renderUntilCompleted(mockRender),
           ).rejects.toEqual(mockError);
         });
       });
@@ -278,7 +278,7 @@ describe('defineAsyncSsrManager', () => {
 
           const mockRender = jest.fn(() => {
             asyncSsrManager.scheduleRerender(
-              new Promise<never>(() => undefined)
+              new Promise<never>(() => undefined),
             );
 
             return 'testHtml';
@@ -287,8 +287,8 @@ describe('defineAsyncSsrManager', () => {
           return expect(
             useFakeTimers(
               async () => asyncSsrManager.renderUntilCompleted(mockRender),
-              5
-            )
+              5,
+            ),
           ).rejects.toEqual(new Error('Got rendering timeout after 5 ms.'));
         });
       });
@@ -307,7 +307,7 @@ describe('defineAsyncSsrManager', () => {
           const mockRender = jest.fn(() => 'testHtml');
 
           await useFakeTimers(async () =>
-            asyncSsrManager.renderUntilCompleted(mockRender)
+            asyncSsrManager.renderUntilCompleted(mockRender),
           );
 
           expect(stubbedLogger.warn.mock.calls).toEqual([
@@ -341,7 +341,7 @@ describe('defineAsyncSsrManager', () => {
         const mockRender = jest.fn(() => 'testHtml');
 
         await useFakeTimers(async () =>
-          asyncSsrManager.renderUntilCompleted(mockRender)
+          asyncSsrManager.renderUntilCompleted(mockRender),
         );
 
         expect(consoleWarnSpy.mock.calls).toEqual([

--- a/packages/async-ssr-manager/src/__tests__/use-fake-timers.ts
+++ b/packages/async-ssr-manager/src/__tests__/use-fake-timers.ts
@@ -2,7 +2,7 @@ const queueMacroTask = setImmediate;
 
 export async function useFakeTimers<TResult>(
   createPromise: () => Promise<TResult>,
-  expectedTimeout?: number
+  expectedTimeout?: number,
 ): Promise<TResult> {
   jest.useFakeTimers();
 
@@ -13,7 +13,7 @@ export async function useFakeTimers<TResult>(
 
     promise.then(
       () => (pending = false),
-      () => (pending = false)
+      () => (pending = false),
     );
 
     await new Promise(queueMacroTask);

--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -88,7 +88,7 @@ export interface AsyncSsrManagerDependencies extends FeatureServices {
  * @see [[AsyncSsrManagerV1]] for further information.
  */
 export function defineAsyncSsrManager(
-  options: AsyncSsrManagerOptions = {}
+  options: AsyncSsrManagerOptions = {},
 ): FeatureServiceProviderDefinition<
   SharedAsyncSsrManager,
   AsyncSsrManagerDependencies

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager-context.ts
@@ -6,7 +6,7 @@ export interface AsyncSsrManagerContext {
 }
 
 export function createAsyncSsrManagerContext(
-  featureServices: AsyncSsrManagerDependencies
+  featureServices: AsyncSsrManagerDependencies,
 ): AsyncSsrManagerContext {
   const logger = featureServices['s2:logger'] || console;
 

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -13,17 +13,17 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
 
   public constructor(
     private readonly context: AsyncSsrManagerContext,
-    private readonly timeout?: number
+    private readonly timeout?: number,
   ) {}
 
   public async renderUntilCompleted(
-    render: () => Promise<string> | string
+    render: () => Promise<string> | string,
   ): Promise<string> {
     const renderPromise = this.renderingLoop(render);
 
     if (typeof this.timeout !== 'number') {
       this.context.logger.warn(
-        'No timeout is configured for the Async SSR Manager. This could lead to unexpectedly long render times or, in the worst case, never resolving render calls!'
+        'No timeout is configured for the Async SSR Manager. This could lead to unexpectedly long render times or, in the worst case, never resolving render calls!',
       );
 
       return renderPromise;
@@ -33,13 +33,13 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
   }
 
   public scheduleRerender(
-    asyncOperation: Promise<unknown> = Promise.resolve()
+    asyncOperation: Promise<unknown> = Promise.resolve(),
   ): void {
     this.asyncOperations.add(asyncOperation);
   }
 
   private async renderingLoop(
-    render: () => Promise<string> | string
+    render: () => Promise<string> | string,
   ): Promise<string> {
     let html = await render();
 
@@ -50,7 +50,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
         // current asynchronous operations are running.
 
         const asyncOperationsSnapshot = Array.from(
-          this.asyncOperations.values()
+          this.asyncOperations.values(),
         );
 
         this.asyncOperations.clear();

--- a/packages/async-ssr-manager/src/internal/set-timeout-async.ts
+++ b/packages/async-ssr-manager/src/internal/set-timeout-async.ts
@@ -1,5 +1,5 @@
 export async function setTimeoutAsync(duration: number): Promise<void> {
   return new Promise<void>((resolve: () => void) =>
-    setTimeout(resolve, duration)
+    setTimeout(resolve, duration),
   );
 }

--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -47,8 +47,8 @@ describe('createFeatureHub()', () => {
 
         expect(() =>
           featureAppManager.getAsyncFeatureAppDefinition(
-            'http://example.com/test.js'
-          )
+            'http://example.com/test.js',
+          ),
         ).toThrowError(new Error('No module loader provided.'));
       });
     });
@@ -68,7 +68,7 @@ describe('createFeatureHub()', () => {
       it('uses the module loader to load the Feature App definition', () => {
         const {featureAppManager} = createFeatureHub(
           'test:integrator',
-          featureHubOptions
+          featureHubOptions,
         );
 
         const url = 'http://example.com/test.js';
@@ -98,12 +98,12 @@ describe('createFeatureHub()', () => {
     it('creates a Feature App', () => {
       const {featureAppManager} = createFeatureHub(
         'test:integrator',
-        featureHubOptions
+        featureHubOptions,
       );
 
       const {featureApp} = featureAppManager.createFeatureAppScope(
         'test:feature-app',
-        mockFeatureAppDefinition
+        mockFeatureAppDefinition,
       );
 
       expect(mockFeatureAppCreate).toHaveBeenCalledWith({
@@ -122,16 +122,16 @@ describe('createFeatureHub()', () => {
       it('throws for a Feature App with mismatching externals', () => {
         const {featureAppManager} = createFeatureHub(
           'test:integrator',
-          featureHubOptions
+          featureHubOptions,
         );
 
         expect(() =>
           featureAppManager.createFeatureAppScope(
             'test:feature-app',
-            mockFeatureAppDefinition
-          )
+            mockFeatureAppDefinition,
+          ),
         ).toThrowError(
-          new Error('The external dependency "foo" is not provided.')
+          new Error('The external dependency "foo" is not provided.'),
         );
       });
     });
@@ -155,7 +155,7 @@ describe('createFeatureHub()', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {featureAppName, parentFeatureApp}
+          {featureAppName, parentFeatureApp},
         );
 
         expect(mockOnBind.mock.calls).toEqual([
@@ -215,9 +215,9 @@ describe('createFeatureHub()', () => {
 
       it('throws for a Feature Service with mismatching externals', () => {
         expect(() =>
-          createFeatureHub('test:integrator', featureHubOptions)
+          createFeatureHub('test:integrator', featureHubOptions),
         ).toThrowError(
-          new Error('The external dependency "foo" is not provided.')
+          new Error('The external dependency "foo" is not provided.'),
         );
       });
     });
@@ -226,7 +226,7 @@ describe('createFeatureHub()', () => {
       it('creates a Feature Hub that contains an empty set of Feature Services', () => {
         const {featureServices} = createFeatureHub(
           'test:integrator',
-          featureHubOptions
+          featureHubOptions,
         );
 
         expect(featureServices).toEqual({});
@@ -244,7 +244,7 @@ describe('createFeatureHub()', () => {
       it('creates a Feature Hub that contains Feature Services that are bound to the integrator', () => {
         const {featureServices} = createFeatureHub(
           'test:integrator',
-          featureHubOptions
+          featureHubOptions,
         );
 
         expect(mockFeatureServiceV1Binder.mock.calls).toEqual([
@@ -252,7 +252,7 @@ describe('createFeatureHub()', () => {
         ]);
 
         expect(featureServices['test:feature-service']).toBe(
-          mockFeatureServiceV1
+          mockFeatureServiceV1,
         );
       });
     });
@@ -293,7 +293,7 @@ describe('createFeatureHub()', () => {
 
         featureAppManager.createFeatureAppScope(
           'test:feature-app',
-          featureAppDefinition
+          featureAppDefinition,
         );
 
         expect(logger.info.mock.calls).toEqual(expectedLogCalls);
@@ -318,7 +318,7 @@ describe('createFeatureHub()', () => {
 
         featureAppManager.createFeatureAppScope(
           'test:feature-app',
-          featureAppDefinition
+          featureAppDefinition,
         );
 
         expect(consoleInfoSpy.mock.calls).toEqual(expectedLogCalls);

--- a/packages/core/src/__tests__/externals-validator.test.ts
+++ b/packages/core/src/__tests__/externals-validator.test.ts
@@ -5,16 +5,16 @@ describe('ExternalsValidator', () => {
     it('throws an error for provided externals containing an invalid version', () => {
       expect(() => new ExternalsValidator({react: 'invalid'})).toThrowError(
         new Error(
-          'The provided version "invalid" for the external "react" is invalid.'
-        )
+          'The provided version "invalid" for the external "react" is invalid.',
+        ),
       );
     });
 
     it('throws an error for provided externals containing a coercable version', () => {
       expect(() => new ExternalsValidator({react: '2.0'})).toThrowError(
         new Error(
-          'The provided version "2.0" for the external "react" is invalid.'
-        )
+          'The provided version "2.0" for the external "react" is invalid.',
+        ),
       );
     });
   });
@@ -35,8 +35,8 @@ describe('ExternalsValidator', () => {
         validator.validate({react: '^16.7.0'});
       }).toThrowError(
         new Error(
-          'The external dependency "react" in the required version range "^16.7.0" is not satisfied. The provided version is "16.6.0".'
-        )
+          'The external dependency "react" in the required version range "^16.7.0" is not satisfied. The provided version is "16.6.0".',
+        ),
       );
     });
 
@@ -46,7 +46,7 @@ describe('ExternalsValidator', () => {
       expect(() => {
         validator.validate({react: '^16.7.0'});
       }).toThrowError(
-        new Error('The external dependency "react" is not provided.')
+        new Error('The external dependency "react" is not provided.'),
       );
     });
 
@@ -57,8 +57,8 @@ describe('ExternalsValidator', () => {
         validator.validate({react: 'invalid'});
       }).toThrowError(
         new Error(
-          'The external dependency "react" in the required version range "invalid" is not satisfied. The provided version is "16.6.0".'
-        )
+          'The external dependency "react" in the required version range "invalid" is not satisfied. The provided version is "16.6.0".',
+        ),
       );
     });
   });

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -64,7 +64,7 @@ describe('FeatureAppManager', () => {
 
     it('logs an info message when the Feature App module was loaded', async () => {
       const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
-        '/example.js'
+        '/example.js',
       );
 
       expect(logger.info.mock.calls).toEqual([]);
@@ -80,7 +80,7 @@ describe('FeatureAppManager', () => {
 
     it('returns an async value for a Feature App definition', async () => {
       const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
-        '/example.js'
+        '/example.js',
       );
 
       expect(asyncFeatureAppDefinition.value).toBeUndefined();
@@ -123,7 +123,7 @@ describe('FeatureAppManager', () => {
 
         const asyncFeatureAppDefinitionA = featureAppManager.getAsyncFeatureAppDefinition(
           url,
-          'a'
+          'a',
         );
 
         const featureAppDefinitionA = await asyncFeatureAppDefinitionA.promise;
@@ -132,7 +132,7 @@ describe('FeatureAppManager', () => {
 
         const asyncFeatureAppDefinitionB = featureAppManager.getAsyncFeatureAppDefinition(
           url,
-          'b'
+          'b',
         );
 
         const featureAppDefinitionB = await asyncFeatureAppDefinitionB.promise;
@@ -142,24 +142,24 @@ describe('FeatureAppManager', () => {
 
       it('returns an async value containing an error for an missing module type', async () => {
         const expectedError = new Error(
-          'The Feature App module at the url "/example.js" with no specific module type is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method. Hint: The provided module loader expects an optional second parameter `moduleType`. It might need to be provided for this Feature App.'
+          'The Feature App module at the url "/example.js" with no specific module type is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method. Hint: The provided module loader expects an optional second parameter `moduleType`. It might need to be provided for this Feature App.',
         );
 
         await expect(
-          featureAppManager.getAsyncFeatureAppDefinition('/example.js').promise
+          featureAppManager.getAsyncFeatureAppDefinition('/example.js').promise,
         ).rejects.toEqual(expectedError);
       });
 
       it('returns an async value containing an error for an unknown module type', async () => {
         const expectedError = new Error(
-          'The Feature App module at the url "/example.js" with the module type "unknown" is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method.'
+          'The Feature App module at the url "/example.js" with the module type "unknown" is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method.',
         );
 
         await expect(
           featureAppManager.getAsyncFeatureAppDefinition(
             '/example.js',
-            'unknown'
-          ).promise
+            'unknown',
+          ).promise,
         ).rejects.toEqual(expectedError);
       });
     });
@@ -180,19 +180,19 @@ describe('FeatureAppManager', () => {
 
         it('throws an error (and stores it on the async value)', async () => {
           const expectedError = new Error(
-            'The Feature App module at the url "/example.js" with no specific module type is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method.'
+            'The Feature App module at the url "/example.js" with no specific module type is invalid. A Feature App module must have a Feature App definition as default export. A Feature App definition is an object with at least a `create` method.',
           );
 
           await expect(
             featureAppManager.getAsyncFeatureAppDefinition('/example.js')
-              .promise
+              .promise,
           ).rejects.toEqual(expectedError);
 
           expect(
-            featureAppManager.getAsyncFeatureAppDefinition('/example.js').error
+            featureAppManager.getAsyncFeatureAppDefinition('/example.js').error,
           ).toEqual(expectedError);
         });
-      }
+      },
     );
 
     it('throws an error if no module loader was provided', () => {
@@ -201,18 +201,18 @@ describe('FeatureAppManager', () => {
       });
 
       expect(() =>
-        featureAppManager.getAsyncFeatureAppDefinition('/example.js')
+        featureAppManager.getAsyncFeatureAppDefinition('/example.js'),
       ).toThrowError(new Error('No module loader provided.'));
     });
 
     describe('for a known Feature App module url', () => {
       it('returns the same async Feature App definition', () => {
         const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
-          '/example.js'
+          '/example.js',
         );
 
         expect(
-          featureAppManager.getAsyncFeatureAppDefinition('/example.js')
+          featureAppManager.getAsyncFeatureAppDefinition('/example.js'),
         ).toBe(asyncFeatureAppDefinition);
       });
     });
@@ -231,11 +231,11 @@ describe('FeatureAppManager', () => {
       featureAppManager.createFeatureAppScope(
         featureAppId,
         mockFeatureAppDefinition,
-        {baseUrl, config}
+        {baseUrl, config},
       );
 
       expect(
-        mockFeatureServiceRegistry.bindFeatureServices.mock.calls
+        mockFeatureServiceRegistry.bindFeatureServices.mock.calls,
       ).toEqual([[mockFeatureAppDefinition, featureAppId, undefined]]);
 
       const {featureServices} = mockFeatureServicesBinding;
@@ -270,11 +270,11 @@ describe('FeatureAppManager', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {beforeCreate: mockBeforeCreate}
+          {beforeCreate: mockBeforeCreate},
         );
 
         expect(mockBeforeCreate.mock.calls).toEqual(
-          mockFeatureAppCreate.mock.calls
+          mockFeatureAppCreate.mock.calls,
         );
       });
 
@@ -290,8 +290,8 @@ describe('FeatureAppManager', () => {
                 beforeCreate: () => {
                   throw mockError;
                 },
-              }
-            )
+              },
+            ),
           ).toThrowError(mockError);
 
           expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(1);
@@ -312,7 +312,7 @@ describe('FeatureAppManager', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {done: mockDone}
+          {done: mockDone},
         );
 
         const {featureServices} = mockFeatureServicesBinding;
@@ -342,7 +342,7 @@ describe('FeatureAppManager', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {featureAppName, parentFeatureApp}
+          {featureAppName, parentFeatureApp},
         );
 
         expect(mockOnBind.mock.calls).toEqual([
@@ -368,14 +368,14 @@ describe('FeatureAppManager', () => {
               onBind: () => {
                 throw mockError;
               },
-            }
+            },
           );
 
           expect(() =>
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
-            )
+              mockFeatureAppDefinition,
+            ),
           ).not.toThrow();
 
           expect(logger.error.mock.calls).toEqual([
@@ -397,11 +397,11 @@ describe('FeatureAppManager', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {featureAppName}
+          {featureAppName},
         );
 
         expect(
-          mockFeatureServiceRegistry.bindFeatureServices.mock.calls
+          mockFeatureServiceRegistry.bindFeatureServices.mock.calls,
         ).toEqual([[mockFeatureAppDefinition, featureAppId, featureAppName]]);
       });
 
@@ -416,7 +416,7 @@ describe('FeatureAppManager', () => {
         featureAppManager.createFeatureAppScope(
           featureAppId,
           mockFeatureAppDefinition,
-          {featureAppName}
+          {featureAppName},
         );
 
         const {featureServices} = mockFeatureServicesBinding;
@@ -444,7 +444,7 @@ describe('FeatureAppManager', () => {
           expect(() => {
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
+              mockFeatureAppDefinition,
             );
           }).not.toThrowError();
         });
@@ -483,7 +483,7 @@ describe('FeatureAppManager', () => {
           try {
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
+              mockFeatureAppDefinition,
             );
           } catch {}
 
@@ -496,7 +496,7 @@ describe('FeatureAppManager', () => {
           expect(() => {
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
+              mockFeatureAppDefinition,
             );
           }).toThrowError(mockError);
         });
@@ -517,7 +517,7 @@ describe('FeatureAppManager', () => {
         it('calls the provided ExternalsValidator with the defined externals', () => {
           featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
@@ -529,7 +529,7 @@ describe('FeatureAppManager', () => {
           expect(() => {
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
+              mockFeatureAppDefinition,
             );
           }).not.toThrowError();
         });
@@ -539,7 +539,7 @@ describe('FeatureAppManager', () => {
         it('does not call the provided ExternalsValidator', () => {
           featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           expect(mockExternalsValidator.validate).not.toHaveBeenCalled();
@@ -549,7 +549,7 @@ describe('FeatureAppManager', () => {
           expect(() => {
             featureAppManager.createFeatureAppScope(
               'testId',
-              mockFeatureAppDefinition
+              mockFeatureAppDefinition,
             );
           }).not.toThrowError();
         });
@@ -565,7 +565,7 @@ describe('FeatureAppManager', () => {
         mockFeatureServiceRegistry.bindFeatureServices.mockImplementation(
           () => {
             throw mockError;
-          }
+          },
         );
       });
 
@@ -573,8 +573,8 @@ describe('FeatureAppManager', () => {
         expect(() =>
           featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
-          )
+            mockFeatureAppDefinition,
+          ),
         ).toThrowError(mockError);
       });
     });
@@ -590,8 +590,8 @@ describe('FeatureAppManager', () => {
         expect(() =>
           featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
-          )
+            mockFeatureAppDefinition,
+          ),
         ).toThrowError(mockError);
 
         expect(mockFeatureServicesBindingUnbind).toHaveBeenCalledTimes(1);
@@ -607,7 +607,7 @@ describe('FeatureAppManager', () => {
         mockFeatureServiceRegistry.registerFeatureServices.mockImplementation(
           () => {
             featureServiceRegistryMethodCalls.push('registerFeatureServices');
-          }
+          },
         );
 
         mockFeatureServiceRegistry.bindFeatureServices.mockImplementation(
@@ -615,7 +615,7 @@ describe('FeatureAppManager', () => {
             featureServiceRegistryMethodCalls.push('bindFeatureServices');
 
             return mockFeatureServicesBinding;
-          }
+          },
         );
 
         mockFeatureAppDefinition = {
@@ -631,17 +631,17 @@ describe('FeatureAppManager', () => {
 
         featureAppManager.createFeatureAppScope(
           featureAppId,
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         expect(
-          mockFeatureServiceRegistry.registerFeatureServices.mock.calls
+          mockFeatureServiceRegistry.registerFeatureServices.mock.calls,
         ).toEqual([
           [mockFeatureAppDefinition.ownFeatureServiceDefinitions, featureAppId],
         ]);
 
         expect(
-          mockFeatureServiceRegistry.bindFeatureServices.mock.calls
+          mockFeatureServiceRegistry.bindFeatureServices.mock.calls,
         ).toEqual([[mockFeatureAppDefinition, featureAppId, undefined]]);
 
         expect(featureServiceRegistryMethodCalls).toEqual([
@@ -658,7 +658,7 @@ describe('FeatureAppManager', () => {
 
           featureAppManager = new FeatureAppManager(
             mockFeatureServiceRegistry,
-            {logger}
+            {logger},
           );
 
           const mockBeforeCreate = jest.fn();
@@ -666,19 +666,19 @@ describe('FeatureAppManager', () => {
           featureAppManager.createFeatureAppScope(
             featureAppId,
             mockFeatureAppDefinition,
-            {beforeCreate: mockBeforeCreate}
+            {beforeCreate: mockBeforeCreate},
           );
 
           featureAppManager.createFeatureAppScope(
             featureAppId,
             mockFeatureAppDefinition,
-            {beforeCreate: mockBeforeCreate}
+            {beforeCreate: mockBeforeCreate},
           );
 
           expect(mockBeforeCreate.mock.calls).toHaveLength(1);
 
           expect(mockBeforeCreate.mock.calls).toEqual(
-            mockFeatureAppCreate.mock.calls
+            mockFeatureAppCreate.mock.calls,
           );
         });
 
@@ -688,7 +688,7 @@ describe('FeatureAppManager', () => {
 
             featureAppManager = new FeatureAppManager(
               mockFeatureServiceRegistry,
-              {logger}
+              {logger},
             );
 
             const mockBeforeCreate = jest.fn();
@@ -696,7 +696,7 @@ describe('FeatureAppManager', () => {
             const featureAppScope = featureAppManager.createFeatureAppScope(
               featureAppId,
               mockFeatureAppDefinition,
-              {beforeCreate: mockBeforeCreate}
+              {beforeCreate: mockBeforeCreate},
             );
 
             featureAppScope.release();
@@ -704,13 +704,13 @@ describe('FeatureAppManager', () => {
             featureAppManager.createFeatureAppScope(
               featureAppId,
               mockFeatureAppDefinition,
-              {beforeCreate: mockBeforeCreate}
+              {beforeCreate: mockBeforeCreate},
             );
 
             expect(mockBeforeCreate.mock.calls).toHaveLength(2);
 
             expect(mockBeforeCreate.mock.calls).toEqual(
-              mockFeatureAppCreate.mock.calls
+              mockFeatureAppCreate.mock.calls,
             );
           });
         });
@@ -719,7 +719,7 @@ describe('FeatureAppManager', () => {
       it('logs an info message after creation', () => {
         featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         expect(logger.info.mock.calls).toEqual([
@@ -732,12 +732,12 @@ describe('FeatureAppManager', () => {
       it('returns a new Feature App scope containing the same Feature App instance', () => {
         const featureAppScope1 = featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         const featureAppScope2 = featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         expect(featureAppScope2).not.toBe(featureAppScope1);
@@ -753,7 +753,7 @@ describe('FeatureAppManager', () => {
 
         const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         expect(featureAppScope.featureApp).toBe(mockFeatureApp);
@@ -764,7 +764,7 @@ describe('FeatureAppManager', () => {
       it('unbinds the bound Feature Services', () => {
         const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         featureAppScope.release();
@@ -778,7 +778,7 @@ describe('FeatureAppManager', () => {
 
           const featureAppScope1 = featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           mockFeatureServicesBindingUnbind.mockImplementation(() => {
@@ -791,11 +791,11 @@ describe('FeatureAppManager', () => {
 
           const featureAppScope2 = featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           expect(featureAppScope1.featureApp).not.toBe(
-            featureAppScope2.featureApp
+            featureAppScope2.featureApp,
           );
         });
       });
@@ -804,12 +804,12 @@ describe('FeatureAppManager', () => {
         it('unbinds the bound Feature Services after the second scope has been released', () => {
           const featureAppScope1 = featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           const featureAppScope2 = featureAppManager.createFeatureAppScope(
             'testId',
-            mockFeatureAppDefinition
+            mockFeatureAppDefinition,
           );
 
           featureAppScope1.release();
@@ -823,7 +823,7 @@ describe('FeatureAppManager', () => {
       it('logs a warning when release is called multiple times', () => {
         const featureAppScope = featureAppManager.createFeatureAppScope(
           'testId',
-          mockFeatureAppDefinition
+          mockFeatureAppDefinition,
         );
 
         featureAppScope.release();
@@ -850,7 +850,7 @@ describe('FeatureAppManager', () => {
       await featureAppManager.preloadFeatureApp('/example.js');
 
       const asyncFeatureAppDefinition = featureAppManager.getAsyncFeatureAppDefinition(
-        '/example.js'
+        '/example.js',
       );
 
       expect(asyncFeatureAppDefinition.value).toBe(mockFeatureAppDefinition);
@@ -862,7 +862,7 @@ describe('FeatureAppManager', () => {
       });
 
       expect(() =>
-        featureAppManager.getAsyncFeatureAppDefinition('/example.js')
+        featureAppManager.getAsyncFeatureAppDefinition('/example.js'),
       ).toThrowError(new Error('No module loader provided.'));
     });
   });
@@ -882,7 +882,7 @@ describe('FeatureAppManager', () => {
     it('logs messages using the console', () => {
       featureAppManager.createFeatureAppScope(
         'testId',
-        mockFeatureAppDefinition
+        mockFeatureAppDefinition,
       );
 
       expect(consoleInfoSpy.mock.calls).toEqual([

--- a/packages/core/src/__tests__/feature-service-registry.test.ts
+++ b/packages/core/src/__tests__/feature-service-registry.test.ts
@@ -127,17 +127,17 @@ describe('FeatureServiceRegistry', () => {
     it('registers the Feature Services "a", "b", "c" one after the other', () => {
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionA],
-        'test'
+        'test',
       );
 
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionB],
-        'test'
+        'test',
       );
 
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionC],
-        'test'
+        'test',
       );
 
       testRegistrationOrderABC();
@@ -146,7 +146,7 @@ describe('FeatureServiceRegistry', () => {
     it('registers the Feature Services "a", "b", "c" all at once in topologically sorted order', () => {
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionB, providerDefinitionC, providerDefinitionA],
-        'test'
+        'test',
       );
 
       testRegistrationOrderABC();
@@ -155,12 +155,12 @@ describe('FeatureServiceRegistry', () => {
     it('does not register the already existing Feature Service "b"', () => {
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionA, providerDefinitionB],
-        'test'
+        'test',
       );
 
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionB],
-        'test'
+        'test',
       );
 
       expect(providerDefinitionB.create.mock.calls).toEqual([
@@ -194,7 +194,7 @@ describe('FeatureServiceRegistry', () => {
 
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionA],
-        'test'
+        'test',
       );
 
       expect(providerDefinitionA.create.mock.calls).toEqual([
@@ -212,12 +212,12 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionC],
-          'test'
-        )
+          'test',
+        ),
       ).toThrowError(
         new Error(
-          'The required Feature Service "a" is not registered and therefore could not be bound to consumer "c".'
-        )
+          'The required Feature Service "a" is not registered and therefore could not be bound to consumer "c".',
+        ),
       );
     });
 
@@ -231,8 +231,8 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionB],
-          'test'
-        )
+          'test',
+        ),
       ).not.toThrowError();
 
       expect(logger.info.mock.calls).toEqual([
@@ -255,12 +255,12 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, stateProviderD],
-          'test'
-        )
+          'test',
+        ),
       ).toThrowError(
         new Error(
-          'The required Feature Service "a" in the unsupported version range "^2.0.0" could not be bound to consumer "d". The supported versions are ["1.1.0"].'
-        )
+          'The required Feature Service "a" in the unsupported version range "^2.0.0" could not be bound to consumer "d". The supported versions are ["1.1.0"].',
+        ),
       );
     });
 
@@ -274,8 +274,8 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, stateProviderD],
-          'test'
-        )
+          'test',
+        ),
       ).not.toThrowError();
 
       expect(logger.info.mock.calls).toEqual([
@@ -301,12 +301,12 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, stateProviderDefinitionD],
-          'test'
-        )
+          'test',
+        ),
       ).toThrowError(
         new Error(
-          'The required Feature Service "a" in an invalid version could not be bound to consumer "d".'
-        )
+          'The required Feature Service "a" in an invalid version could not be bound to consumer "d".',
+        ),
       );
     });
 
@@ -320,8 +320,8 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, stateProviderDefinitionD],
-          'test'
-        )
+          'test',
+        ),
       ).not.toThrowError();
 
       expect(logger.info.mock.calls).toEqual([
@@ -346,12 +346,12 @@ describe('FeatureServiceRegistry', () => {
       expect(() =>
         featureServiceRegistry.registerFeatureServices(
           [stateProviderDefinitionD],
-          'test'
-        )
+          'test',
+        ),
       ).toThrowError(
         new Error(
-          'The Feature Service "d" could not be registered by registrant "test" because it defines the invalid version "2.0".'
-        )
+          'The Feature Service "d" could not be registered by registrant "test" because it defines the invalid version "2.0".',
+        ),
       );
     });
 
@@ -372,7 +372,7 @@ describe('FeatureServiceRegistry', () => {
           expect(() => {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           }).not.toThrowError();
         });
@@ -411,7 +411,7 @@ describe('FeatureServiceRegistry', () => {
           try {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           } catch {}
 
@@ -424,7 +424,7 @@ describe('FeatureServiceRegistry', () => {
           expect(() => {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           }).toThrowError(mockError);
         });
@@ -446,7 +446,7 @@ describe('FeatureServiceRegistry', () => {
           try {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           } catch {}
 
@@ -459,7 +459,7 @@ describe('FeatureServiceRegistry', () => {
           expect(() => {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           }).not.toThrowError();
         });
@@ -469,7 +469,7 @@ describe('FeatureServiceRegistry', () => {
         it('does not call the provided ExternalsValidator', () => {
           featureServiceRegistry.registerFeatureServices(
             [providerDefinitionA],
-            'test'
+            'test',
           );
 
           expect(mockExternalsValidator.validate).not.toHaveBeenCalled();
@@ -479,7 +479,7 @@ describe('FeatureServiceRegistry', () => {
           expect(() => {
             featureServiceRegistry.registerFeatureServices(
               [providerDefinitionA],
-              'test'
+              'test',
             );
           }).not.toThrowError();
         });
@@ -503,7 +503,7 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA],
-          'test'
+          'test',
         );
 
         expect(binderA.mock.calls).toEqual([]);
@@ -511,8 +511,8 @@ describe('FeatureServiceRegistry', () => {
         expect(
           featureServiceRegistry.bindFeatureServices(
             {dependencies: {featureServices: {a: '^1.0.0'}}},
-            'foo'
-          )
+            'foo',
+          ),
         ).toEqual({
           featureServices: {a: featureServiceA},
           unbind: expect.any(Function),
@@ -528,7 +528,7 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA],
-          'test'
+          'test',
         );
 
         expect(binderA.mock.calls).toEqual([]);
@@ -536,8 +536,8 @@ describe('FeatureServiceRegistry', () => {
         expect(
           featureServiceRegistry.bindFeatureServices(
             {dependencies: {featureServices: {a: '~1.0.0'}}},
-            'foo'
-          )
+            'foo',
+          ),
         ).toEqual({
           featureServices: {a: featureServiceA},
           unbind: expect.any(Function),
@@ -553,7 +553,7 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA],
-          'test'
+          'test',
         );
 
         expect(binderA.mock.calls).toEqual([]);
@@ -561,8 +561,8 @@ describe('FeatureServiceRegistry', () => {
         expect(
           featureServiceRegistry.bindFeatureServices(
             {dependencies: {featureServices: {a: '1.0.0'}}},
-            'foo'
-          )
+            'foo',
+          ),
         ).toEqual({
           featureServices: {a: featureServiceA},
           unbind: expect.any(Function),
@@ -580,7 +580,7 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA],
-          'test'
+          'test',
         );
 
         expect(binderA.mock.calls).toEqual([]);
@@ -588,8 +588,8 @@ describe('FeatureServiceRegistry', () => {
         expect(
           featureServiceRegistry.bindFeatureServices(
             {optionalDependencies: {featureServices: {a: '1.1.0'}}},
-            'foo'
-          )
+            'foo',
+          ),
         ).toEqual({featureServices: {}, unbind: expect.any(Function)});
 
         expect(binderA.mock.calls).toEqual([]);
@@ -603,7 +603,7 @@ describe('FeatureServiceRegistry', () => {
 
           featureServiceRegistry.registerFeatureServices(
             [providerDefinitionA],
-            'test'
+            'test',
           );
 
           expect(binderA.mock.calls).toEqual([]);
@@ -615,8 +615,8 @@ describe('FeatureServiceRegistry', () => {
                   featureServices: {b: '1.0.0', a: '1.1.0'},
                 },
               },
-              'foo'
-            )
+              'foo',
+            ),
           ).toEqual({
             featureServices: {a: featureServiceA},
             unbind: expect.any(Function),
@@ -632,7 +632,7 @@ describe('FeatureServiceRegistry', () => {
 
           featureServiceRegistry.registerFeatureServices(
             [providerDefinitionA],
-            'test'
+            'test',
           );
 
           expect(binderA.mock.calls).toEqual([]);
@@ -644,8 +644,8 @@ describe('FeatureServiceRegistry', () => {
                   featureServices: {a: '1.1.0', b: '1.0.0'},
                 },
               },
-              'foo'
-            )
+              'foo',
+            ),
           ).toEqual({
             featureServices: {a: featureServiceA},
             unbind: expect.any(Function),
@@ -661,7 +661,7 @@ describe('FeatureServiceRegistry', () => {
 
           featureServiceRegistry.registerFeatureServices(
             [providerDefinitionA, providerDefinitionB],
-            'test'
+            'test',
           );
 
           expect(binderA.mock.calls).toEqual([['b', undefined]]);
@@ -673,8 +673,8 @@ describe('FeatureServiceRegistry', () => {
                   featureServices: {a: '1.1.0', b: '^1.0.0'},
                 },
               },
-              'foo'
-            )
+              'foo',
+            ),
           ).toEqual({
             featureServices: {a: featureServiceA, b: featureServiceB},
             unbind: expect.any(Function),
@@ -696,15 +696,15 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, providerDefinitionB],
-          'testId'
+          'testId',
         );
 
         expect(
           featureServiceRegistry.bindFeatureServices(
             {dependencies: {featureServices: {a: '^1.0.0', b: '^1.0.0'}}},
             'testId',
-            'testName'
-          )
+            'testName',
+          ),
         ).toEqual({
           featureServices: {a: featureServiceA, b: featureServiceB},
           unbind: expect.any(Function),
@@ -723,11 +723,11 @@ describe('FeatureServiceRegistry', () => {
       featureServiceRegistry.bindFeatureServices({}, 'foo');
 
       expect(() =>
-        featureServiceRegistry.bindFeatureServices({}, 'foo')
+        featureServiceRegistry.bindFeatureServices({}, 'foo'),
       ).toThrowError(
         new Error(
-          'All required Feature Services are already bound to consumer "foo".'
-        )
+          'All required Feature Services are already bound to consumer "foo".',
+        ),
       );
     });
 
@@ -735,7 +735,7 @@ describe('FeatureServiceRegistry', () => {
       it('unbinds the consumer', () => {
         const bindings = featureServiceRegistry.bindFeatureServices(
           providerDefinitionA,
-          providerDefinitionA.id
+          providerDefinitionA.id,
         );
 
         bindings.unbind();
@@ -743,8 +743,8 @@ describe('FeatureServiceRegistry', () => {
         expect(() =>
           featureServiceRegistry.bindFeatureServices(
             providerDefinitionA,
-            providerDefinitionA.id
-          )
+            providerDefinitionA.id,
+          ),
         ).not.toThrowError();
       });
 
@@ -761,7 +761,7 @@ describe('FeatureServiceRegistry', () => {
 
         featureServiceRegistry.registerFeatureServices(
           [providerDefinitionA, providerDefinitionB, providerDefinitionC],
-          'test'
+          'test',
         );
 
         const bindings = featureServiceRegistry.bindFeatureServices(
@@ -770,7 +770,7 @@ describe('FeatureServiceRegistry', () => {
               featureServices: {a: '1.1.0', b: '1.0.0', c: '2.0.0'},
             },
           },
-          'foo'
+          'foo',
         );
 
         bindings.unbind();
@@ -825,35 +825,35 @@ describe('FeatureServiceRegistry', () => {
       it('fails to unbind an already unbound consumer', () => {
         const bindings = featureServiceRegistry.bindFeatureServices(
           providerDefinitionA,
-          providerDefinitionA.id
+          providerDefinitionA.id,
         );
 
         bindings.unbind();
 
         expect(() => bindings.unbind()).toThrowError(
           new Error(
-            'All required Feature Services are already unbound from consumer "a".'
-          )
+            'All required Feature Services are already unbound from consumer "a".',
+          ),
         );
       });
 
       it('fails to unbind an already unbound consumer, even if this consumer has been re-bound', () => {
         const bindings = featureServiceRegistry.bindFeatureServices(
           providerDefinitionA,
-          providerDefinitionA.id
+          providerDefinitionA.id,
         );
 
         bindings.unbind();
 
         featureServiceRegistry.bindFeatureServices(
           providerDefinitionA,
-          providerDefinitionA.id
+          providerDefinitionA.id,
         );
 
         expect(() => bindings.unbind()).toThrowError(
           new Error(
-            'All required Feature Services are already unbound from consumer "a".'
-          )
+            'All required Feature Services are already unbound from consumer "a".',
+          ),
         );
       });
     });
@@ -874,7 +874,7 @@ describe('FeatureServiceRegistry', () => {
     it('logs messages using the console', () => {
       featureServiceRegistry.registerFeatureServices(
         [providerDefinitionA],
-        'test'
+        'test',
       );
 
       expect(consoleInfoSpy.mock.calls).toEqual([

--- a/packages/core/src/async-value.ts
+++ b/packages/core/src/async-value.ts
@@ -7,7 +7,7 @@ export class AsyncValue<TValue> {
   public constructor(
     public readonly promise: Promise<TValue>,
     public value?: TValue,
-    public error?: Error
+    public error?: Error,
   ) {
     promise
       .then((val) => (this.value = val))

--- a/packages/core/src/create-feature-hub.ts
+++ b/packages/core/src/create-feature-hub.ts
@@ -87,7 +87,7 @@ export interface FeatureHubOptions {
  */
 export function createFeatureHub(
   integratorId: string,
-  options: FeatureHubOptions = {}
+  options: FeatureHubOptions = {},
 ): FeatureHub {
   const {
     featureServiceDefinitions,
@@ -116,7 +116,7 @@ export function createFeatureHub(
   if (featureServiceDefinitions) {
     featureServiceRegistry.registerFeatureServices(
       featureServiceDefinitions,
-      integratorId
+      integratorId,
     );
   }
 
@@ -129,7 +129,7 @@ export function createFeatureHub(
 
   const {featureServices} = featureServiceRegistry.bindFeatureServices(
     integratorDefinition,
-    integratorId
+    integratorId,
   );
 
   return {featureAppManager, featureServiceRegistry, featureServices};

--- a/packages/core/src/externals-validator.ts
+++ b/packages/core/src/externals-validator.ts
@@ -27,13 +27,13 @@ export class ExternalsValidator {
    */
   public constructor(private readonly providedExternals: ProvidedExternals) {
     for (const [externalName, providedVersion] of Object.entries(
-      providedExternals
+      providedExternals,
     )) {
       if (!semverValid(providedVersion)) {
         throw new Error(
           `The provided version ${JSON.stringify(
-            providedVersion
-          )} for the external ${JSON.stringify(externalName)} is invalid.`
+            providedVersion,
+          )} for the external ${JSON.stringify(externalName)} is invalid.`,
         );
       }
     }
@@ -46,27 +46,27 @@ export class ExternalsValidator {
    */
   public validate(requiredExternals: RequiredExternals): void {
     for (const [externalName, versionRange] of Object.entries(
-      requiredExternals
+      requiredExternals,
     )) {
       const providedVersion = this.providedExternals[externalName];
 
       if (!providedVersion) {
         throw new Error(
           `The external dependency ${JSON.stringify(
-            externalName
-          )} is not provided.`
+            externalName,
+          )} is not provided.`,
         );
       }
 
       if (!semverSatisfies(providedVersion, versionRange)) {
         throw new Error(
           `The external dependency ${JSON.stringify(
-            externalName
+            externalName,
           )} in the required version range ${JSON.stringify(
-            versionRange
+            versionRange,
           )} is not satisfied. The provided version is ${JSON.stringify(
-            providedVersion
-          )}.`
+            providedVersion,
+          )}.`,
         );
       }
     }

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -79,7 +79,7 @@ export interface FeatureAppDefinition<
  */
 export type ModuleLoader = (
   url: string,
-  moduleType?: string
+  moduleType?: string,
 ) => Promise<unknown>;
 
 export interface FeatureAppScope<TFeatureApp> {
@@ -118,7 +118,7 @@ export interface FeatureAppScopeOptions<
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    env: FeatureAppEnvironment<TFeatureServices, TConfig>
+    env: FeatureAppEnvironment<TFeatureServices, TConfig>,
   ) => void;
 
   /**
@@ -210,7 +210,7 @@ export class FeatureAppManager {
 
   public constructor(
     private readonly featureServiceRegistry: FeatureServiceRegistry,
-    private readonly options: FeatureAppManagerOptions = {}
+    private readonly options: FeatureAppManagerOptions = {},
   ) {
     this.logger = options.logger || console;
   }
@@ -236,7 +236,7 @@ export class FeatureAppManager {
    */
   public getAsyncFeatureAppDefinition(
     url: string,
-    moduleType?: string
+    moduleType?: string,
   ): AsyncValue<FeatureAppDefinition<unknown>> {
     const key = `${url}${moduleType}`;
     let asyncFeatureAppDefinition = this.asyncFeatureAppDefinitions.get(key);
@@ -244,7 +244,7 @@ export class FeatureAppManager {
     if (!asyncFeatureAppDefinition) {
       asyncFeatureAppDefinition = this.createAsyncFeatureAppDefinition(
         url,
-        moduleType
+        moduleType,
       );
 
       this.asyncFeatureAppDefinitions.set(key, asyncFeatureAppDefinition);
@@ -286,7 +286,7 @@ export class FeatureAppManager {
       TFeatureServices,
       TConfig
     >,
-    options: FeatureAppScopeOptions<TFeatureServices, TConfig> = {}
+    options: FeatureAppScopeOptions<TFeatureServices, TConfig> = {},
   ): FeatureAppScope<TFeatureApp> {
     const featureAppRetainer = this.getFeatureAppRetainer<
       TFeatureApp,
@@ -303,8 +303,8 @@ export class FeatureAppManager {
         if (released) {
           this.logger.warn(
             `The Feature App with the ID ${JSON.stringify(
-              featureAppId
-            )} has already been released for this scope.`
+              featureAppId,
+            )} has already been released for this scope.`,
           );
         } else {
           released = true;
@@ -331,14 +331,14 @@ export class FeatureAppManager {
    */
   public async preloadFeatureApp(
     url: string,
-    moduleType?: string
+    moduleType?: string,
   ): Promise<void> {
     await this.getAsyncFeatureAppDefinition(url, moduleType).promise;
   }
 
   private createAsyncFeatureAppDefinition(
     url: string,
-    moduleType?: string
+    moduleType?: string,
   ): AsyncValue<FeatureAppDefinition<unknown>> {
     const {moduleLoader: loadModule} = this.options;
 
@@ -353,29 +353,29 @@ export class FeatureAppManager {
             Messages.invalidFeatureAppModule(
               url,
               moduleType,
-              this.options.moduleLoader
-            )
+              this.options.moduleLoader,
+            ),
           );
         }
 
         this.logger.info(
           `The Feature App module at the url ${JSON.stringify(
-            url
-          )} has been successfully loaded.`
+            url,
+          )} has been successfully loaded.`,
         );
 
         return featureAppModule.default;
-      })
+      }),
     );
   }
 
   private registerOwnFeatureServices(
     featureAppId: string,
-    featureAppDefinition: FeatureAppDefinition<unknown>
+    featureAppDefinition: FeatureAppDefinition<unknown>,
   ): void {
     if (
       this.featureAppDefinitionsWithRegisteredOwnFeatureServices.has(
-        featureAppDefinition
+        featureAppDefinition,
       )
     ) {
       return;
@@ -384,12 +384,12 @@ export class FeatureAppManager {
     if (featureAppDefinition.ownFeatureServiceDefinitions) {
       this.featureServiceRegistry.registerFeatureServices(
         featureAppDefinition.ownFeatureServiceDefinitions,
-        featureAppId
+        featureAppId,
       );
     }
 
     this.featureAppDefinitionsWithRegisteredOwnFeatureServices.add(
-      featureAppDefinition
+      featureAppDefinition,
     );
   }
 
@@ -404,7 +404,7 @@ export class FeatureAppManager {
       TFeatureServices,
       TConfig
     >,
-    options: FeatureAppScopeOptions<TFeatureServices, TConfig>
+    options: FeatureAppScopeOptions<TFeatureServices, TConfig>,
   ): FeatureAppRetainer<TFeatureApp> {
     let featureAppRetainer = this.featureAppRetainers.get(featureAppId);
 
@@ -416,7 +416,7 @@ export class FeatureAppManager {
       featureAppRetainer = this.createFeatureAppRetainer(
         featureAppDefinition,
         featureAppId,
-        options
+        options,
       );
     }
 
@@ -434,7 +434,7 @@ export class FeatureAppManager {
       TConfig
     >,
     featureAppId: string,
-    options: FeatureAppScopeOptions<TFeatureServices, TConfig>
+    options: FeatureAppScopeOptions<TFeatureServices, TConfig>,
   ): FeatureAppRetainer<TFeatureApp> {
     this.validateExternals(featureAppDefinition);
 
@@ -450,7 +450,7 @@ export class FeatureAppManager {
     const binding = this.featureServiceRegistry.bindFeatureServices(
       featureAppDefinition,
       featureAppId,
-      featureAppName
+      featureAppName,
     );
 
     try {
@@ -480,8 +480,8 @@ export class FeatureAppManager {
 
       this.logger.info(
         `The Feature App with the ID ${JSON.stringify(
-          featureAppId
-        )} has been successfully created.`
+          featureAppId,
+        )} has been successfully created.`,
       );
 
       let retainCount = 1;
@@ -514,7 +514,7 @@ export class FeatureAppManager {
   }
 
   private validateExternals(
-    featureAppDefinition: FeatureServiceConsumerDefinition
+    featureAppDefinition: FeatureServiceConsumerDefinition,
   ): void {
     const {externalsValidator} = this.options;
 

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -57,7 +57,7 @@ export interface FeatureServiceProviderDefinition<
   readonly id: string;
 
   create(
-    env: FeatureServiceEnvironment<TFeatureServices>
+    env: FeatureServiceEnvironment<TFeatureServices>,
   ): TSharedFeatureService | undefined;
 }
 
@@ -75,7 +75,7 @@ export interface FeatureServiceBinding<TFeatureService> {
  */
 export type FeatureServiceBinder<TFeatureService> = (
   consumerId: string,
-  consumerName?: string
+  consumerName?: string,
 ) => FeatureServiceBinding<TFeatureService>;
 
 export interface SharedFeatureService {
@@ -129,14 +129,14 @@ function mergeFeatureServiceDependencies({
 }
 
 function createDependencyGraph(
-  definitions: FeatureServiceProviderDefinition<SharedFeatureService>[]
+  definitions: FeatureServiceProviderDefinition<SharedFeatureService>[],
 ): DependencyGraph {
   const dependencyGraph: DependencyGraph = new Map();
 
   for (const definition of definitions) {
     dependencyGraph.set(
       definition.id,
-      mergeFeatureServiceDependencies(definition)
+      mergeFeatureServiceDependencies(definition),
     );
   }
 
@@ -145,17 +145,17 @@ function createDependencyGraph(
 
 function isOptionalFeatureServiceDependency(
   {optionalDependencies}: FeatureServiceConsumerDefinition,
-  providerId: ProviderId
+  providerId: ProviderId,
 ): boolean {
   return Boolean(
     optionalDependencies &&
       optionalDependencies.featureServices &&
-      optionalDependencies.featureServices.hasOwnProperty(providerId)
+      optionalDependencies.featureServices.hasOwnProperty(providerId),
   );
 }
 
 function createProviderDefinitionsById(
-  definitions: FeatureServiceProviderDefinition<SharedFeatureService>[]
+  definitions: FeatureServiceProviderDefinition<SharedFeatureService>[],
 ): ProviderDefinitionsById {
   const providerDefinitionsById: ProviderDefinitionsById = new Map();
 
@@ -181,7 +181,7 @@ export class FeatureServiceRegistry {
   private readonly logger: Logger;
 
   public constructor(
-    private readonly options: FeatureServiceRegistryOptions = {}
+    private readonly options: FeatureServiceRegistryOptions = {},
   ) {
     this.logger = options.logger || console;
   }
@@ -208,10 +208,10 @@ export class FeatureServiceRegistry {
     providerDefinitions: FeatureServiceProviderDefinition<
       SharedFeatureService
     >[],
-    registrantId: string
+    registrantId: string,
   ): void {
     const providerDefinitionsById = createProviderDefinitionsById(
-      providerDefinitions
+      providerDefinitions,
     );
 
     const dependencyGraph = createDependencyGraph(providerDefinitions);
@@ -220,7 +220,7 @@ export class FeatureServiceRegistry {
       this.registerFeatureService(
         providerDefinitionsById,
         providerId,
-        registrantId
+        registrantId,
       );
     }
   }
@@ -241,7 +241,7 @@ export class FeatureServiceRegistry {
   public bindFeatureServices(
     consumerDefinition: FeatureServiceConsumerDefinition,
     consumerId: string,
-    consumerName?: string
+    consumerName?: string,
   ): FeatureServicesBinding {
     if (this.consumerIds.has(consumerId)) {
       throw new Error(Messages.featureServicesAlreadyBound(consumerId));
@@ -254,7 +254,7 @@ export class FeatureServiceRegistry {
     for (const providerId of Object.keys(allDependencies)) {
       const optional = isOptionalFeatureServiceDependency(
         consumerDefinition,
-        providerId
+        providerId,
       );
 
       const versionRange = allDependencies[providerId];
@@ -264,7 +264,7 @@ export class FeatureServiceRegistry {
         consumerId,
         consumerName,
         versionRange,
-        {optional}
+        {optional},
       );
 
       if (!binding) {
@@ -272,7 +272,7 @@ export class FeatureServiceRegistry {
       }
 
       this.logger.info(
-        Messages.featureServiceSuccessfullyBound(providerId, consumerId)
+        Messages.featureServiceSuccessfullyBound(providerId, consumerId),
       );
 
       bindings.set(providerId, binding);
@@ -300,12 +300,12 @@ export class FeatureServiceRegistry {
           }
 
           this.logger.info(
-            Messages.featureServiceSuccessfullyUnbound(providerId, consumerId)
+            Messages.featureServiceSuccessfullyUnbound(providerId, consumerId),
           );
         } catch (error) {
           this.logger.error(
             Messages.featureServiceCouldNotBeUnbound(providerId, consumerId),
-            error
+            error,
           );
         }
       }
@@ -317,7 +317,7 @@ export class FeatureServiceRegistry {
   private registerFeatureService(
     providerDefinitionsById: ProviderDefinitionsById,
     providerId: string,
-    registrantId: string
+    registrantId: string,
   ): void {
     const providerDefinition = providerDefinitionsById.get(providerId);
 
@@ -327,7 +327,7 @@ export class FeatureServiceRegistry {
 
     if (this.sharedFeatureServices.has(providerId)) {
       this.logger.warn(
-        Messages.featureServiceAlreadyRegistered(providerId, registrantId)
+        Messages.featureServiceAlreadyRegistered(providerId, registrantId),
       );
 
       return;
@@ -337,7 +337,7 @@ export class FeatureServiceRegistry {
 
     const {featureServices} = this.bindFeatureServices(
       providerDefinition,
-      providerId
+      providerId,
     );
 
     const sharedFeatureService = providerDefinition.create({featureServices});
@@ -346,17 +346,17 @@ export class FeatureServiceRegistry {
       this.validateFeatureServiceVersions(
         sharedFeatureService,
         providerId,
-        registrantId
+        registrantId,
       );
 
       this.sharedFeatureServices.set(providerId, sharedFeatureService);
 
       this.logger.info(
-        Messages.featureServiceSuccessfullyRegistered(providerId, registrantId)
+        Messages.featureServiceSuccessfullyRegistered(providerId, registrantId),
       );
     } else {
       this.logger.info(
-        Messages.featureServiceReturnedUndefined(providerId, registrantId)
+        Messages.featureServiceReturnedUndefined(providerId, registrantId),
       );
     }
   }
@@ -366,7 +366,7 @@ export class FeatureServiceRegistry {
     consumerId: string,
     consumerName: string | undefined,
     versionRange: string | undefined,
-    {optional}: {optional: boolean}
+    {optional}: {optional: boolean},
   ): FeatureServiceBinding<unknown> | undefined {
     const coercedVersion = versionRange && semverCoerce(versionRange);
 
@@ -374,7 +374,7 @@ export class FeatureServiceRegistry {
       const message = Messages.featureServiceDependencyVersionInvalid(
         optional,
         providerId,
-        consumerId
+        consumerId,
       );
 
       if (optional) {
@@ -393,7 +393,7 @@ export class FeatureServiceRegistry {
       const message = Messages.featureServiceNotRegistered(
         optional,
         providerId,
-        consumerId
+        consumerId,
       );
 
       if (optional) {
@@ -408,7 +408,7 @@ export class FeatureServiceRegistry {
     const supportedVersions = Object.keys(sharedFeatureService);
 
     const version = supportedVersions.find((supportedVersion) =>
-      semverSatisfies(supportedVersion, caretRange)
+      semverSatisfies(supportedVersion, caretRange),
     );
 
     const bindFeatureService = version
@@ -421,7 +421,7 @@ export class FeatureServiceRegistry {
         providerId,
         consumerId,
         caretRange,
-        supportedVersions
+        supportedVersions,
       );
 
       if (optional) {
@@ -437,7 +437,7 @@ export class FeatureServiceRegistry {
   }
 
   private validateExternals(
-    featureAppDefinition: FeatureServiceConsumerDefinition
+    featureAppDefinition: FeatureServiceConsumerDefinition,
   ): void {
     const {externalsValidator} = this.options;
 
@@ -455,7 +455,7 @@ export class FeatureServiceRegistry {
   private validateFeatureServiceVersions(
     sharedFeatureService: SharedFeatureService,
     providerId: string,
-    registrantId: string
+    registrantId: string,
   ): void {
     for (const version of Object.keys(sharedFeatureService)) {
       if (!semverValid(version)) {
@@ -463,8 +463,8 @@ export class FeatureServiceRegistry {
           Messages.featureServiceVersionInvalid(
             providerId,
             registrantId,
-            version
-          )
+            version,
+          ),
         );
       }
     }

--- a/packages/core/src/internal/feature-app-manager-messages.ts
+++ b/packages/core/src/internal/feature-app-manager-messages.ts
@@ -3,7 +3,7 @@ import {ModuleLoader} from '../feature-app-manager';
 export function invalidFeatureAppModule(
   url: string,
   moduleType: string | undefined,
-  moduleLoader: ModuleLoader | undefined
+  moduleLoader: ModuleLoader | undefined,
 ): string {
   let message = `The Feature App module at the url ${JSON.stringify(url)} ${
     moduleType

--- a/packages/core/src/internal/feature-service-registry-messages.ts
+++ b/packages/core/src/internal/feature-service-registry-messages.ts
@@ -3,129 +3,129 @@ export function featureServiceUnsupported(
   providerId: string,
   consumerId: string,
   versionRange: string,
-  supportedVersions: string[]
+  supportedVersions: string[],
 ): string {
   return `The ${
     optional ? 'optional' : 'required'
   } Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} in the unsupported version range ${JSON.stringify(
-    versionRange
+    versionRange,
   )} could not be bound to consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}. The supported versions are ${JSON.stringify(supportedVersions)}.`;
 }
 
 export function featureServiceVersionInvalid(
   providerId: string,
   registrantId: string,
-  version: string
+  version: string,
 ): string | undefined {
   return `The Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} could not be registered by registrant ${JSON.stringify(
-    registrantId
+    registrantId,
   )} because it defines the invalid version ${JSON.stringify(version)}.`;
 }
 
 export function featureServiceDependencyVersionInvalid(
   optional: boolean,
   providerId: string,
-  consumerId: string
+  consumerId: string,
 ): string {
   return `The ${
     optional ? 'optional' : 'required'
   } Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} in an invalid version could not be bound to consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}.`;
 }
 
 export function featureServiceNotRegistered(
   optional: boolean,
   providerId: string,
-  consumerId: string
+  consumerId: string,
 ): string {
   return `The ${
     optional ? 'optional' : 'required'
   } Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} is not registered and therefore could not be bound to consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}.`;
 }
 
 export function featureServiceReturnedUndefined(
   providerId: string,
-  registrantId: string
+  registrantId: string,
 ): string {
   return `The Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} could not be registered by registrant ${JSON.stringify(
-    registrantId
+    registrantId,
   )} because it returned undefined.`;
 }
 
 export function featureServiceSuccessfullyRegistered(
   providerId: string,
-  registrantId: string
+  registrantId: string,
 ): string {
   return `The Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} has been successfully registered by registrant ${JSON.stringify(
-    registrantId
+    registrantId,
   )}.`;
 }
 
 export function featureServiceAlreadyRegistered(
   providerId: string,
-  registrantId: string
+  registrantId: string,
 ): string {
   return `The already registered Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} could not be re-registered by registrant ${JSON.stringify(registrantId)}.`;
 }
 
 export function featureServiceSuccessfullyBound(
   providerId: string,
-  consumerId: string
+  consumerId: string,
 ): string {
   return `The required Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} has been successfully bound to consumer ${JSON.stringify(consumerId)}.`;
 }
 
 export function featureServicesAlreadyBound(
-  consumerId: string
+  consumerId: string,
 ): string | undefined {
   return `All required Feature Services are already bound to consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}.`;
 }
 
 export function featureServiceCouldNotBeUnbound(
   providerId: string,
-  consumerId: string
+  consumerId: string,
 ): string {
   return `The required Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} could not be unbound from consumer ${JSON.stringify(consumerId)}.`;
 }
 
 export function featureServiceSuccessfullyUnbound(
   providerId: string,
-  consumerId: string
+  consumerId: string,
 ): string {
   return `The required Feature Service ${JSON.stringify(
-    providerId
+    providerId,
   )} has been successfully unbound from consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}.`;
 }
 
 export function featureServicesAlreadyUnbound(consumerId: string): string {
   return `All required Feature Services are already unbound from consumer ${JSON.stringify(
-    consumerId
+    consumerId,
   )}.`;
 }

--- a/packages/core/src/internal/is-feature-app-module.ts
+++ b/packages/core/src/internal/is-feature-app-module.ts
@@ -6,7 +6,7 @@ export interface FeatureAppModule {
 
 function isFeatureAppDefinition(
   // tslint:disable-next-line:no-any
-  maybeFeatureAppDefinition: any
+  maybeFeatureAppDefinition: any,
 ): maybeFeatureAppDefinition is FeatureAppDefinition<unknown> {
   if (
     typeof maybeFeatureAppDefinition !== 'object' ||
@@ -24,13 +24,13 @@ function isFeatureAppDefinition(
 
 export function isFeatureAppModule(
   // tslint:disable-next-line:no-any
-  maybeFeatureAppModule: any
+  maybeFeatureAppModule: any,
 ): maybeFeatureAppModule is FeatureAppModule {
   if (typeof maybeFeatureAppModule !== 'object' || !maybeFeatureAppModule) {
     return false;
   }
 
   return isFeatureAppDefinition(
-    (maybeFeatureAppModule as FeatureAppModule).default
+    (maybeFeatureAppModule as FeatureAppModule).default,
   );
 }

--- a/packages/core/src/internal/toposort-dependencies.ts
+++ b/packages/core/src/internal/toposort-dependencies.ts
@@ -9,20 +9,20 @@ export type DependencyGraph = Map<string, Dependencies>;
 type DependencyEdges = [string, string][];
 
 function createTuple<TFirst, TSecond>(
-  first: TFirst
+  first: TFirst,
 ): (second: TSecond) => [TFirst, TSecond] {
   return (second) => [first, second];
 }
 
 function createDependencyEdges(
   dependentName: string,
-  dependencies: Dependencies
+  dependencies: Dependencies,
 ): DependencyEdges {
   return Object.keys(dependencies).map(createTuple(dependentName));
 }
 
 function createAllDependencyEdges(
-  dependencyGraph: DependencyGraph
+  dependencyGraph: DependencyGraph,
 ): DependencyEdges {
   return Array.from(dependencyGraph.keys()).reduce(
     (allDependencyEdges, dependencyName) => {
@@ -35,17 +35,17 @@ function createAllDependencyEdges(
 
       const dependencyEdges = createDependencyEdges(
         dependencyName,
-        dependencies
+        dependencies,
       );
 
       return [...allDependencyEdges, ...dependencyEdges];
     },
-    [] as DependencyEdges
+    [] as DependencyEdges,
   );
 }
 
 export function toposortDependencies(
-  dependencyGraph: DependencyGraph
+  dependencyGraph: DependencyGraph,
 ): string[] {
   const dependencyNames = Array.from(dependencyGraph.keys());
   const dependencyEdges = createAllDependencyEdges(dependencyGraph);
@@ -57,8 +57,8 @@ export function toposortDependencies(
     ...dependencyNames.filter(
       (dependencyName) =>
         dependencyGraph.has(dependencyName) &&
-        sortedDependencyNames.indexOf(dependencyName) === -1
-    )
+        sortedDependencyNames.indexOf(dependencyName) === -1,
+    ),
   );
 
   // Reverse array to yield execution order.

--- a/packages/demos/src/advanced-routing/hello-world-feature-app.tsx
+++ b/packages/demos/src/advanced-routing/hello-world-feature-app.tsx
@@ -17,7 +17,7 @@ function HelloWorldText({helloWorldService}: HelloWorldTextProps): JSX.Element {
 
   React.useEffect(
     () => helloWorldService.listen(() => setName(helloWorldService.name)),
-    [helloWorldService]
+    [helloWorldService],
   );
 
   return (

--- a/packages/demos/src/advanced-routing/index.test.ts
+++ b/packages/demos/src/advanced-routing/index.test.ts
@@ -26,7 +26,7 @@ class HelloWorldUi {
     await (await this.getNewNameInput()).type(name);
 
     await this.browser.waitForNavigation(
-      (await this.getSubmitButton()).click()
+      (await this.getSubmitButton()).click(),
     );
   }
 

--- a/packages/demos/src/advanced-routing/integrator.tsx
+++ b/packages/demos/src/advanced-routing/integrator.tsx
@@ -25,7 +25,7 @@ const {featureAppManager, featureServices} = createFeatureHub(
     providedExternals: {react: process.env.REACT_VERSION as string},
     featureServiceDefinitions: [
       defineHistoryService(
-        createRootLocationTransformer({consumerPathsQueryParamName: '---'})
+        createRootLocationTransformer({consumerPathsQueryParamName: '---'}),
       ),
       navigationServiceDefinition,
       helloWorldServiceDefinition,
@@ -33,7 +33,7 @@ const {featureAppManager, featureServices} = createFeatureHub(
     featureServiceDependencies: {
       [navigationServiceDefinition.id]: '^1.0.0',
     },
-  }
+  },
 );
 
 const navigationService = featureServices[
@@ -47,5 +47,5 @@ ReactDOM.render(
     </HistoryRouter>
   </FeatureHubContextProvider>,
 
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/advanced-routing/navigation-service.ts
+++ b/packages/demos/src/advanced-routing/navigation-service.ts
@@ -63,7 +63,7 @@ export const navigationServiceDefinition: FeatureServiceProviderDefinition<
 
             const {state, ...to} = createNewRootLocationForMultipleConsumers(
               pageLocation,
-              helloWorldLocation
+              helloWorldLocation,
             );
 
             rootHistory.push(to, state);

--- a/packages/demos/src/app-renderer.d.ts
+++ b/packages/demos/src/app-renderer.d.ts
@@ -19,5 +19,5 @@ export interface AppRendererResult {
 }
 
 export type AppRenderer = (
-  options: AppRendererOptions
+  options: AppRendererOptions,
 ) => Promise<AppRendererResult>;

--- a/packages/demos/src/browser.ts
+++ b/packages/demos/src/browser.ts
@@ -11,7 +11,7 @@ export class Browser {
 
   public async goto(
     url: string,
-    timeout: number = this.defaultNavigationTimeout
+    timeout: number = this.defaultNavigationTimeout,
   ): Promise<void> {
     await page.goto(url, {timeout});
   }
@@ -30,7 +30,7 @@ export class Browser {
 
   public async waitForNavigation(
     cause: Promise<unknown>,
-    timeout: number = this.defaultNavigationTimeout
+    timeout: number = this.defaultNavigationTimeout,
   ): Promise<void> {
     await Promise.all([page.waitForNavigation({timeout}), cause]);
   }

--- a/packages/demos/src/custom-logging/app.tsx
+++ b/packages/demos/src/custom-logging/app.tsx
@@ -9,7 +9,7 @@ export interface AppProps {
   readonly useConsumerName: boolean;
 
   readonly beforeCreate?: (
-    env: FeatureAppEnvironment<FeatureServices, undefined>
+    env: FeatureAppEnvironment<FeatureServices, undefined>,
   ) => void;
 }
 

--- a/packages/demos/src/custom-logging/index.test.ts
+++ b/packages/demos/src/custom-logging/index.test.ts
@@ -37,9 +37,9 @@ describe('integration test: "custom logging"', () => {
     const messages = await Promise.all(
       consoleMessages.map(async (consoleMessage) =>
         Promise.all(
-          consoleMessage.args().map(async (handle) => handle.jsonValue())
-        )
-      )
+          consoleMessage.args().map(async (handle) => handle.jsonValue()),
+        ),
+      ),
     );
 
     expect(messages).toContainEqual([

--- a/packages/demos/src/custom-logging/integrator.node.tsx
+++ b/packages/demos/src/custom-logging/integrator.node.tsx
@@ -19,7 +19,7 @@ export default async function renderApp({
     providedExternals: {react: process.env.REACT_VERSION as string},
     featureServiceDefinitions: [
       defineLogger((consumerId, consumerName) =>
-        logger.child({consumerId, consumerName})
+        logger.child({consumerId, consumerName}),
       ),
     ],
   });
@@ -29,7 +29,7 @@ export default async function renderApp({
   const html = ReactDOM.renderToString(
     <FeatureHubContextProvider value={{featureAppManager, logger}}>
       <App useConsumerName={useConsumerName} />
-    </FeatureHubContextProvider>
+    </FeatureHubContextProvider>,
   );
 
   return {html};

--- a/packages/demos/src/custom-logging/integrator.tsx
+++ b/packages/demos/src/custom-logging/integrator.tsx
@@ -10,12 +10,12 @@ import {App} from './app';
 defineExternals({react: React});
 
 const useConsumerName = Boolean(
-  new URLSearchParams(window.location.search).get('consumerName')
+  new URLSearchParams(window.location.search).get('consumerName'),
 );
 
 const createConsumerConsole: ConsumerLoggerCreator = (
   consumerId,
-  consumerName
+  consumerName,
 ) => {
   const prefix = useConsumerName ? consumerName || consumerId : consumerId;
   const prefixArgs = [`%c${prefix}`, 'font-weight: bold'];
@@ -36,7 +36,7 @@ const {featureAppManager, featureServices} = createFeatureHub(
     providedExternals: {react: process.env.REACT_VERSION as string},
     featureServiceDefinitions: [defineLogger(createConsumerConsole)],
     featureServiceDependencies: {'s2:logger': '^1.0.0'},
-  }
+  },
 );
 
 const logger = featureServices['s2:logger'] as Logger;
@@ -50,5 +50,5 @@ ReactDOM.hydrate(
       }
     />
   </FeatureHubContextProvider>,
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.node.tsx
@@ -31,7 +31,7 @@ export default async function renderApp({
         src="feature-app.umd.js"
         serverSrc={featureAppNodeUrl}
       />
-    </FeatureHubContextProvider>
+    </FeatureHubContextProvider>,
   );
 
   return {html};

--- a/packages/demos/src/feature-app-in-feature-app/integrator.tsx
+++ b/packages/demos/src/feature-app-in-feature-app/integrator.tsx
@@ -26,5 +26,5 @@ ReactDOM.render(
     />
   </FeatureHubContextProvider>,
 
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/history-service/index.test.ts
+++ b/packages/demos/src/history-service/index.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(120000);
 class HistoryConsumerUi {
   public constructor(
     private readonly browser: Browser,
-    private readonly specifier: 'a' | 'b'
+    private readonly specifier: 'a' | 'b',
   ) {}
 
   public async getPathname(): Promise<unknown> {
@@ -29,7 +29,7 @@ class HistoryConsumerUi {
     await (await this.getElement('new-path-input')).type(pathname);
 
     await this.browser.waitForNavigation(
-      (await this.getElement('push-button')).click()
+      (await this.getElement('push-button')).click(),
     );
   }
 
@@ -37,19 +37,19 @@ class HistoryConsumerUi {
     await (await this.getElement('new-path-input')).type(pathname);
 
     await this.browser.waitForNavigation(
-      (await this.getElement('replace-button')).click()
+      (await this.getElement('replace-button')).click(),
     );
   }
 
   public async clickPushLink(): Promise<void> {
     await this.browser.waitForNavigation(
-      (await this.getElement('push-link')).click()
+      (await this.getElement('push-link')).click(),
     );
   }
 
   public async clickReplaceLink(): Promise<void> {
     await this.browser.waitForNavigation(
-      (await this.getElement('replace-link')).click()
+      (await this.getElement('replace-link')).click(),
     );
   }
 
@@ -92,11 +92,11 @@ describe('integration test: "history-service"', () => {
 
   test('Scenario 2: The user loads a page with consumer-specific pathnames', async () => {
     await browser.goto(
-      `${url}?test:history-consumer:a=/a1&test:history-consumer:b=/b1`
+      `${url}?test:history-consumer:a=/a1&test:history-consumer:b=/b1`,
     );
 
     expect(await browser.getPath()).toBe(
-      '/?test:history-consumer:a=/a1&test:history-consumer:b=/b1'
+      '/?test:history-consumer:a=/a1&test:history-consumer:b=/b1',
     );
 
     expect(await a.getPathname()).toBe('/a1');
@@ -148,7 +148,7 @@ describe('integration test: "history-service"', () => {
     await b.push('/b1');
 
     expect(await browser.getPath()).toBe(
-      '/?test:history-consumer:a=/a1&test:history-consumer:b=/b1'
+      '/?test:history-consumer:a=/a1&test:history-consumer:b=/b1',
     );
 
     expect(await a.getPathname()).toBe('/a1');
@@ -202,7 +202,7 @@ describe('integration test: "history-service"', () => {
     await page.setJavaScriptEnabled(false);
 
     await browser.goto(
-      `${url}?test:history-consumer:a=/a1&test:history-consumer:b=/b1`
+      `${url}?test:history-consumer:a=/a1&test:history-consumer:b=/b1`,
     );
 
     expect(await a.getPathname()).toBe('/a1');
@@ -226,7 +226,7 @@ describe('integration test: "history-service"', () => {
     await b.clickReplaceLink();
 
     expect(await browser.getPath()).toBe(
-      '/?test:history-consumer:a=/foo&test:history-consumer:b=/bar'
+      '/?test:history-consumer:a=/foo&test:history-consumer:b=/bar',
     );
 
     expect(await a.getPathname()).toBe('/foo');

--- a/packages/demos/src/history-service/integrator.node.tsx
+++ b/packages/demos/src/history-service/integrator.node.tsx
@@ -18,7 +18,7 @@ export default async function renderApp({
   });
 
   const html = ReactDOM.renderToString(
-    <App featureAppManager={featureAppManager} />
+    <App featureAppManager={featureAppManager} />,
   );
 
   return {html};

--- a/packages/demos/src/history-service/integrator.tsx
+++ b/packages/demos/src/history-service/integrator.tsx
@@ -12,5 +12,5 @@ const {featureAppManager} = createFeatureHub('test:integrator', {
 
 ReactDOM.render(
   <App featureAppManager={featureAppManager} />,
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/integrator-dom/index.test.ts
+++ b/packages/demos/src/integrator-dom/index.test.ts
@@ -36,7 +36,7 @@ describe('integration test: "dom integrator"', () => {
           document
             .querySelector('feature-app-loader')
             ?.shadowRoot?.querySelector('feature-app-container')?.shadowRoot
-            ?.textContent
+            ?.textContent,
       );
 
       expect(content).toMatch('Hello, World!');
@@ -67,7 +67,7 @@ describe('integration test: "dom integrator"', () => {
         () =>
           document
             .querySelector('feature-app-loader')
-            ?.shadowRoot?.querySelector('slot')?.name
+            ?.shadowRoot?.querySelector('slot')?.name,
       );
 
       expect(slotName).toBe('error');
@@ -96,7 +96,7 @@ describe('integration test: "dom integrator"', () => {
         () =>
           document
             .querySelector('feature-app-loader')
-            ?.shadowRoot?.querySelector('slot')?.name
+            ?.shadowRoot?.querySelector('slot')?.name,
       );
 
       expect(slotName).toBe('loading');

--- a/packages/demos/src/module-loader-amd/integrator.tsx
+++ b/packages/demos/src/module-loader-amd/integrator.tsx
@@ -20,5 +20,5 @@ ReactDOM.render(
     />
   </FeatureHubContextProvider>,
 
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/module-loader-commonjs/integrator.node.tsx
+++ b/packages/demos/src/module-loader-commonjs/integrator.node.tsx
@@ -27,7 +27,7 @@ export default async function renderApp({
         src=""
         serverSrc={featureAppNodeUrl}
       />
-    </FeatureHubContextProvider>
+    </FeatureHubContextProvider>,
   );
 
   return {html};

--- a/packages/demos/src/module-loader-federation/integrator.tsx
+++ b/packages/demos/src/module-loader-federation/integrator.tsx
@@ -21,5 +21,5 @@ ReactDOM.render(
     />
   </FeatureHubContextProvider>,
 
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/module-loader-multiple/integrator.tsx
+++ b/packages/demos/src/module-loader-multiple/integrator.tsx
@@ -26,5 +26,5 @@ ReactDOM.render(
     />
   </FeatureHubContextProvider>,
 
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/react-loading-and-error-ui/feature-app.tsx
+++ b/packages/demos/src/react-loading-and-error-ui/feature-app.tsx
@@ -28,7 +28,7 @@ const App: React.FunctionComponent<AppProps> = ({
   loadingError,
 }) => {
   const [serverResponse, setServerResponse] = React.useState<string | null>(
-    null
+    null,
   );
 
   React.useEffect(() => {
@@ -56,7 +56,7 @@ const featureAppDefinition: FeatureAppDefinition<ReactFeatureApp> = {
     let reject: (err: Error) => void;
 
     const loadingPromise: Promise<void> = new Promise(
-      (res, rej) => ([resolve, reject] = [res, rej])
+      (res, rej) => ([resolve, reject] = [res, rej]),
     );
 
     return {

--- a/packages/demos/src/react-loading-and-error-ui/integrator.tsx
+++ b/packages/demos/src/react-loading-and-error-ui/integrator.tsx
@@ -52,5 +52,5 @@ ReactDOM.render(
       </FeatureAppLoader>
     </FeatureHubContextProvider>
   </div>,
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/server-side-rendering/feature-app.tsx
+++ b/packages/demos/src/server-side-rendering/feature-app.tsx
@@ -40,7 +40,7 @@ const featureAppDefinition: FeatureAppDefinition<
       serializedStateManager.register(() => subject);
 
       asyncSsrManager.scheduleRerender(
-        (async () => (subject = await fetchSubject()))()
+        (async () => (subject = await fetchSubject()))(),
       );
     } else {
       const serializedSubject = serializedStateManager.getSerializedState();

--- a/packages/demos/src/server-side-rendering/integrator.node.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.node.tsx
@@ -40,7 +40,7 @@ export default async function renderApp({
         [asyncSsrManagerDefinition.id]: '^1.0.0',
         [serializedStateManagerDefinition.id]: '^1.0.0',
       },
-    }
+    },
   );
 
   const asyncSsrManager = featureServices[
@@ -68,8 +68,8 @@ export default async function renderApp({
     ReactDOM.renderToString(
       <FeatureHubContextProvider value={featureHubContextValue}>
         <App port={port} />
-      </FeatureHubContextProvider>
-    )
+      </FeatureHubContextProvider>,
+    ),
   );
 
   const serializedStateManager = featureServices[

--- a/packages/demos/src/server-side-rendering/integrator.tsx
+++ b/packages/demos/src/server-side-rendering/integrator.tsx
@@ -10,7 +10,7 @@ import {App} from './app';
 
 function getSerializedStatesFromDom(): string | undefined {
   const scriptElement = document.querySelector(
-    'script[type="x-feature-hub/serialized-states"]'
+    'script[type="x-feature-hub/serialized-states"]',
   );
 
   return (scriptElement && scriptElement.textContent) || undefined;
@@ -18,7 +18,7 @@ function getSerializedStatesFromDom(): string | undefined {
 
 function getUrlsForHydrationFromDom(): FeatureAppModuleSource[] {
   const scriptElement = document.querySelector(
-    'script[type="x-feature-hub/urls-for-hydration"]'
+    'script[type="x-feature-hub/urls-for-hydration"]',
   );
 
   if (!scriptElement || !scriptElement.textContent) {
@@ -44,14 +44,14 @@ function getUrlsForHydrationFromDom(): FeatureAppModuleSource[] {
 
   await Promise.all(
     getUrlsForHydrationFromDom().map(async ({url, moduleType}) =>
-      featureAppManager.preloadFeatureApp(url, moduleType)
-    )
+      featureAppManager.preloadFeatureApp(url, moduleType),
+    ),
   );
 
   ReactDOM.hydrate(
     <FeatureHubContextProvider value={{featureAppManager}}>
       <App />
     </FeatureHubContextProvider>,
-    document.querySelector('main')
+    document.querySelector('main'),
   );
 })().catch(console.error);

--- a/packages/demos/src/start-server.js
+++ b/packages/demos/src/start-server.js
@@ -29,7 +29,7 @@ function createStylesheetLinks(stylesheets) {
  */
 function createDocumentHtml(
   bodyHtml,
-  {serializedStates, stylesheetsForSsr, hydrationSources} = {}
+  {serializedStates, stylesheetsForSsr, hydrationSources} = {},
 ) {
   const stylesheetLinks = stylesheetsForSsr
     ? createStylesheetLinks(Array.from(stylesheetsForSsr.values()))
@@ -42,7 +42,7 @@ function createDocumentHtml(
   const urlsForHydrationScript =
     hydrationSources && hydrationSources.size
       ? `<script type="x-feature-hub/urls-for-hydration">${JSON.stringify(
-          Array.from(hydrationSources.values())
+          Array.from(hydrationSources.values()),
         )}</script>`
       : '';
 
@@ -71,7 +71,7 @@ function createDocumentHtml(
 async function startServer(
   webpackConfigs,
   nodeIntegratorWebpackConfig,
-  demoName
+  demoName,
 ) {
   const port = await getPort(demoName ? {port: 3000} : undefined);
   const app = express();
@@ -104,7 +104,7 @@ async function startServer(
         const renderResult = await renderApp({port, req});
 
         res.send(
-          createDocumentHtml(`<main>${renderResult.html}</main>`, renderResult)
+          createDocumentHtml(`<main>${renderResult.html}</main>`, renderResult),
         );
       } else {
         res.send(createDocumentHtml(`<main></main>`));

--- a/packages/demos/src/todomvc/integrator.tsx
+++ b/packages/demos/src/todomvc/integrator.tsx
@@ -20,7 +20,7 @@ document.head.appendChild(
   Object.assign(document.createElement('link'), {
     rel: 'stylesheet',
     href: 'index.css',
-  })
+  }),
 );
 
 ReactDOM.render(
@@ -44,5 +44,5 @@ ReactDOM.render(
       />
     </section>
   </FeatureHubContextProvider>,
-  document.querySelector('main')
+  document.querySelector('main'),
 );

--- a/packages/demos/src/todomvc/main/todomvc-item.tsx
+++ b/packages/demos/src/todomvc/main/todomvc-item.tsx
@@ -129,7 +129,7 @@ export class TodoMvcItem extends React.PureComponent<
 > {
   public static getDerivedStateFromProps(
     props: TodoMvcItemProps,
-    state: TodoMvcItemState
+    state: TodoMvcItemState,
   ): Partial<TodoMvcItemState> | null {
     if (state.editing || state.editText === props.title) {
       return null;
@@ -185,13 +185,13 @@ export class TodoMvcItem extends React.PureComponent<
   };
 
   private readonly handleEditInputChange = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     this.setState({editText: event.currentTarget.value});
   };
 
   private readonly handleEditInputKeyDown = (
-    event: React.KeyboardEvent<HTMLInputElement>
+    event: React.KeyboardEvent<HTMLInputElement>,
   ) => {
     if (event.key === 'Enter') {
       this.props.onEdit(this.props.id, event.currentTarget.value.trim());

--- a/packages/demos/src/todomvc/todo-manager/index.ts
+++ b/packages/demos/src/todomvc/todo-manager/index.ts
@@ -101,7 +101,7 @@ class TodoManagerV1Impl implements TodoManagerV1 {
   private editTodo<Key extends keyof Todo>(
     id: string,
     key: Key,
-    value: Todo[Key]
+    value: Todo[Key],
   ): void {
     const index = this.todos.findIndex((todo) => todo.id === id);
     const oldTodo = this.todos[index];

--- a/packages/demos/src/todomvc/webpack-config.js
+++ b/packages/demos/src/todomvc/webpack-config.js
@@ -7,7 +7,7 @@ const {webpackBaseConfig} = require('../webpack-base-config');
 
 const websiteBuildDirname = path.resolve(
   __dirname,
-  '../../../website/build/feature-hub/todomvc'
+  '../../../website/build/feature-hub/todomvc',
 );
 
 /**

--- a/packages/demos/src/webpack-base-config.js
+++ b/packages/demos/src/webpack-base-config.js
@@ -51,7 +51,7 @@ const webpackBaseConfig = {
       'process.env.BLUEPRINT_NAMESPACE': '""',
       'process.env.REACT_VERSION': JSON.stringify(getPkgVersion('react')),
       'process.env.FEATURE_HUB_REACT_VERSION': JSON.stringify(
-        getPkgVersion('@feature-hub/react')
+        getPkgVersion('@feature-hub/react'),
       ),
     }),
   ],

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -76,7 +76,7 @@ export interface DefineFeatureAppContainerOptions {
  */
 export function defineFeatureAppContainer(
   featureAppManager: FeatureAppManager,
-  options: DefineFeatureAppContainerOptions = {}
+  options: DefineFeatureAppContainerOptions = {},
 ): void {
   if (customElements.get(elementName)) {
     return;
@@ -122,7 +122,7 @@ export function defineFeatureAppContainer(
             featureAppName: this.featureAppName,
             baseUrl: this.baseUrl,
             config: this.config,
-          }
+          },
         );
 
         this.featureAppScope.featureApp.attachTo(this.appElement);

--- a/packages/dom/src/feature-app-loader.ts
+++ b/packages/dom/src/feature-app-loader.ts
@@ -66,7 +66,7 @@ export interface DefineFeatureAppLoaderOptions {
  */
 export function defineFeatureAppLoader(
   featureAppManager: FeatureAppManager,
-  options: DefineFeatureAppLoaderOptions = {}
+  options: DefineFeatureAppLoaderOptions = {},
 ): void {
   if (customElements.get(elementName)) {
     return;
@@ -105,7 +105,7 @@ export function defineFeatureAppLoader(
         }
 
         const definition = await featureAppManager.getAsyncFeatureAppDefinition(
-          prependBaseUrl(this.baseUrl, this.src)
+          prependBaseUrl(this.baseUrl, this.src),
         ).promise;
 
         return html`

--- a/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
+++ b/packages/history-service/src/__tests__/create-root-location-transformer.test.ts
@@ -16,13 +16,13 @@ describe('#createRootLocationTransformer', () => {
         let rootLocation = locationTransformer.createRootLocation(
           {pathname: '/'},
           {pathname: '/foo'},
-          'test1'
+          'test1',
         );
 
         rootLocation = locationTransformer.createRootLocation(
           rootLocation,
           {pathname: '/bar', search: 'baz=1'},
-          'test2'
+          'test2',
         );
 
         expect(rootLocation).toMatchObject({
@@ -45,7 +45,7 @@ describe('#createRootLocationTransformer', () => {
         const rootLocation = locationTransformer.createRootLocation(
           {pathname: '/'},
           {pathname: '/foo', search: '?bar=1&baz=2', hash: '#qux'},
-          'testPri'
+          'testPri',
         );
 
         expect(rootLocation).toMatchObject({
@@ -66,12 +66,12 @@ describe('#createRootLocationTransformer', () => {
             locationTransformer.createRootLocation(
               {pathname: '/'},
               {pathname: '/foo', search: '?---=1'},
-              'testPri'
-            )
+              'testPri',
+            ),
           ).toThrowError(
             new Error(
-              `Primary consumer tried to set query parameter "---" which is reserverd for consumer paths.`
-            )
+              `Primary consumer tried to set query parameter "---" which is reserverd for consumer paths.`,
+            ),
           );
         });
       });
@@ -87,19 +87,19 @@ describe('#createRootLocationTransformer', () => {
         let rootLocation = locationTransformer.createRootLocation(
           {pathname: '/'},
           {pathname: '/baz', search: '?qux=3'},
-          'test1'
+          'test1',
         );
 
         rootLocation = locationTransformer.createRootLocation(
           rootLocation,
           {pathname: '/foo', search: '?bar=1', hash: '#qux'},
-          'testPri'
+          'testPri',
         );
 
         rootLocation = locationTransformer.createRootLocation(
           rootLocation,
           {pathname: '/some', search: '?thing=else'},
-          'test2'
+          'test2',
         );
 
         expect(rootLocation).toMatchObject({
@@ -131,22 +131,22 @@ describe('#createRootLocationTransformer', () => {
         expect(
           locationTransformer.getConsumerPathFromRootLocation(
             rootLocation as Location,
-            'testPri'
-          )
+            'testPri',
+          ),
         ).toEqual('/foo?bar=1#some-anchor');
 
         expect(
           locationTransformer.getConsumerPathFromRootLocation(
             rootLocation as Location,
-            'test1'
-          )
+            'test1',
+          ),
         ).toEqual('/baz?qux=3');
 
         expect(
           locationTransformer.getConsumerPathFromRootLocation(
             rootLocation as Location,
-            'test2'
-          )
+            'test2',
+          ),
         ).toBeUndefined();
       });
     });
@@ -166,8 +166,8 @@ describe('#createRootLocationTransformer', () => {
         expect(
           locationTransformer.getConsumerPathFromRootLocation(
             rootLocation as Location,
-            'test2'
-          )
+            'test2',
+          ),
         ).toBeUndefined();
       });
     });

--- a/packages/history-service/src/__tests__/index.node.test.ts
+++ b/packages/history-service/src/__tests__/index.node.test.ts
@@ -45,7 +45,7 @@ describe('defineHistoryService', () => {
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(
           createRootLocationTransformer({consumerPathsQueryParamName}),
-          {mode: 'static'}
+          {mode: 'static'},
         ).create(mockEnv);
 
         return sharedHistoryService!['1.0.0'];
@@ -85,7 +85,7 @@ describe('defineHistoryService', () => {
           url: '/example',
           cookies: {},
           headers: {},
-        })
+        }),
       );
 
       afterEach(destroyHistories);
@@ -94,8 +94,8 @@ describe('defineHistoryService', () => {
         it('throws an error', () => {
           expect(() => createHistories(undefined)).toThrowError(
             new Error(
-              'Static history can not be created without a server request.'
-            )
+              'Static history can not be created without a server request.',
+            ),
           );
         });
       });
@@ -103,11 +103,11 @@ describe('defineHistoryService', () => {
       describe('when called multiple times for the same consumer', () => {
         it('returns the same instance and logs a warning', () => {
           expect(historyBinding1.featureService.createStaticHistory()).toEqual(
-            history1
+            history1,
           );
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'createStaticHistory was called multiple times by consumer "test1". Returning the same history instance as before.'
+            'createStaticHistory was called multiple times by consumer "test1". Returning the same history instance as before.',
           );
         });
       });
@@ -259,7 +259,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.staticRootLocation).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -275,7 +275,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.staticRootLocation).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goBack() is not supported.'
+            'history.goBack() is not supported.',
           );
         });
       });
@@ -291,7 +291,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.staticRootLocation).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goForward() is not supported.'
+            'history.goForward() is not supported.',
           );
         });
       });
@@ -310,7 +310,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -332,7 +332,7 @@ describe('defineHistoryService', () => {
           expect(listenSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.listen() is not supported.'
+            'history.listen() is not supported.',
           );
         });
 
@@ -354,8 +354,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar?a=b'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
 
@@ -368,8 +368,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
       });
@@ -402,7 +402,7 @@ describe('defineHistoryService', () => {
         staticHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });
@@ -444,7 +444,7 @@ describe('defineHistoryService', () => {
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(
           createRootLocationTransformer({consumerPathsQueryParamName}),
-          {mode: 'static'}
+          {mode: 'static'},
         ).create(mockEnv);
 
         return sharedHistoryService!['2.0.0'];
@@ -458,8 +458,8 @@ describe('defineHistoryService', () => {
         it('throws an error', () => {
           expect(() => createHistories(undefined)).toThrowError(
             new Error(
-              'Static history can not be created without a server request.'
-            )
+              'Static history can not be created without a server request.',
+            ),
           );
         });
       });
@@ -622,7 +622,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -638,7 +638,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goBack() is not supported.'
+            'history.goBack() is not supported.',
           );
         });
       });
@@ -654,7 +654,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goForward() is not supported.'
+            'history.goForward() is not supported.',
           );
         });
       });
@@ -673,7 +673,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -695,7 +695,7 @@ describe('defineHistoryService', () => {
           expect(listenSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.listen() is not supported.'
+            'history.listen() is not supported.',
           );
         });
 
@@ -717,8 +717,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar?a=b'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
 
@@ -731,8 +731,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
       });
@@ -815,7 +815,7 @@ describe('defineHistoryService', () => {
         staticHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });
@@ -857,7 +857,7 @@ describe('defineHistoryService', () => {
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(
           createRootLocationTransformer({consumerPathsQueryParamName}),
-          {mode: 'static'}
+          {mode: 'static'},
         ).create(mockEnv);
 
         return sharedHistoryService!['3.0.0'];
@@ -871,8 +871,8 @@ describe('defineHistoryService', () => {
         it('throws an error', () => {
           expect(() => createHistories(undefined)).toThrowError(
             new Error(
-              'Static history can not be created without a server request.'
-            )
+              'Static history can not be created without a server request.',
+            ),
           );
         });
       });
@@ -1019,7 +1019,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -1035,7 +1035,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.back() is not supported.'
+            'history.back() is not supported.',
           );
         });
       });
@@ -1051,7 +1051,7 @@ describe('defineHistoryService', () => {
           expect(historyService1.rootHistory.location).toBe(rootLocation);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.forward() is not supported.'
+            'history.forward() is not supported.',
           );
         });
       });
@@ -1070,7 +1070,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -1092,7 +1092,7 @@ describe('defineHistoryService', () => {
           expect(listenSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.listen() is not supported.'
+            'history.listen() is not supported.',
           );
         });
 
@@ -1114,8 +1114,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar?a=b'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
 
@@ -1128,8 +1128,8 @@ describe('defineHistoryService', () => {
           expect(href).toBe(
             createUrl(
               {test1: '/foo', test2: '/bar'},
-              {pathname: '/example', relative: true}
-            )
+              {pathname: '/example', relative: true},
+            ),
           );
         });
       });
@@ -1196,7 +1196,7 @@ describe('defineHistoryService', () => {
         staticHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });

--- a/packages/history-service/src/__tests__/index.test.ts
+++ b/packages/history-service/src/__tests__/index.test.ts
@@ -103,7 +103,7 @@ describe('defineHistoryService', () => {
 
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(
-          createRootLocationTransformer({consumerPathsQueryParamName})
+          createRootLocationTransformer({consumerPathsQueryParamName}),
         ).create(mockEnv);
 
         return sharedHistoryService!['1.0.0'];
@@ -150,11 +150,11 @@ describe('defineHistoryService', () => {
       describe('when called multiple times for the same consumer', () => {
         it('returns the same instance and logs a warning', () => {
           expect(historyBinding1.featureService.createBrowserHistory()).toEqual(
-            history1
+            history1,
           );
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'createBrowserHistory was called multiple times by consumer "test1". Returning the same history instance as before.'
+            'createBrowserHistory was called multiple times by consumer "test1". Returning the same history instance as before.',
           );
         });
       });
@@ -254,7 +254,7 @@ describe('defineHistoryService', () => {
           history2.push('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(pushStateSpy).toHaveBeenCalledTimes(2);
@@ -292,7 +292,7 @@ describe('defineHistoryService', () => {
           history2.replace('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(replaceStateSpy).toHaveBeenCalledTimes(2);
@@ -335,7 +335,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -351,7 +351,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goBack() is not supported.'
+            'history.goBack() is not supported.',
           );
         });
       });
@@ -367,7 +367,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goForward() is not supported.'
+            'history.goForward() is not supported.',
           );
         });
       });
@@ -384,7 +384,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -411,14 +411,14 @@ describe('defineHistoryService', () => {
 
           expect(listenerSpy1).toHaveBeenCalledWith(
             expect.objectContaining({pathname: '/foo', search: '?bar=1'}),
-            'PUSH'
+            'PUSH',
           );
 
           expect(listenerSpy2).toHaveBeenCalledTimes(1);
 
           expect(listenerSpy2).toHaveBeenCalledWith(
             expect.objectContaining({pathname: '/baz', search: '?qux=2'}),
-            'REPLACE'
+            'REPLACE',
           );
         });
 
@@ -465,7 +465,7 @@ describe('defineHistoryService', () => {
 
             expect(history1ListenerSpy).toHaveBeenCalledWith(
               expect.objectContaining({pathname: '/'}),
-              'POP'
+              'POP',
             );
 
             expect(history2ListenerSpy).not.toHaveBeenCalled();
@@ -501,7 +501,7 @@ describe('defineHistoryService', () => {
 
               expect(history1ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/baz', search: '?qux=3'}),
-                'POP'
+                'POP',
               );
 
               history1ListenerSpy.mockClear();
@@ -510,7 +510,7 @@ describe('defineHistoryService', () => {
 
               expect(history1ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/bar', search: '?qux=4'}),
-                'POP'
+                'POP',
               );
             });
           });
@@ -534,7 +534,7 @@ describe('defineHistoryService', () => {
 
               expect(history2ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/b2'}),
-                'POP'
+                'POP',
               );
             });
           });
@@ -561,7 +561,7 @@ describe('defineHistoryService', () => {
                   search: '?a=1',
                   state: consumerState,
                 }),
-                'POP'
+                'POP',
               );
 
               expect(history2ListenerSpy).not.toHaveBeenCalled();
@@ -578,7 +578,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true}),
           );
         });
 
@@ -589,7 +589,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar'}, {relative: true}),
           );
         });
       });
@@ -664,7 +664,7 @@ describe('defineHistoryService', () => {
         browserHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });
@@ -676,7 +676,7 @@ describe('defineHistoryService', () => {
     >>;
 
     let createHistoryServiceBinder: (
-      mode?: 'browser' | 'static'
+      mode?: 'browser' | 'static',
     ) => FeatureServiceBinder<HistoryServiceV2>;
 
     beforeEach(() => {
@@ -686,7 +686,7 @@ describe('defineHistoryService', () => {
 
       createHistoryServiceBinder = () => {
         const sharedHistoryService = defineHistoryService(
-          createRootLocationTransformer({consumerPathsQueryParamName})
+          createRootLocationTransformer({consumerPathsQueryParamName}),
         ).create(mockEnv);
 
         return sharedHistoryService!['2.0.0'];
@@ -836,7 +836,7 @@ describe('defineHistoryService', () => {
           history2.push('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(pushStateSpy).toHaveBeenCalledTimes(2);
@@ -862,7 +862,7 @@ describe('defineHistoryService', () => {
           history2.replace('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(replaceStateSpy).toHaveBeenCalledTimes(2);
@@ -893,7 +893,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -909,7 +909,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goBack() is not supported.'
+            'history.goBack() is not supported.',
           );
         });
       });
@@ -925,7 +925,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.goForward() is not supported.'
+            'history.goForward() is not supported.',
           );
         });
       });
@@ -942,7 +942,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -969,14 +969,14 @@ describe('defineHistoryService', () => {
 
           expect(listenerSpy1).toHaveBeenCalledWith(
             expect.objectContaining({pathname: '/foo', search: '?bar=1'}),
-            'PUSH'
+            'PUSH',
           );
 
           expect(listenerSpy2).toHaveBeenCalledTimes(1);
 
           expect(listenerSpy2).toHaveBeenCalledWith(
             expect.objectContaining({pathname: '/baz', search: '?qux=2'}),
-            'REPLACE'
+            'REPLACE',
           );
         });
 
@@ -1023,7 +1023,7 @@ describe('defineHistoryService', () => {
 
             expect(history1ListenerSpy).toHaveBeenCalledWith(
               expect.objectContaining({pathname: '/'}),
-              'POP'
+              'POP',
             );
 
             expect(history2ListenerSpy).not.toHaveBeenCalled();
@@ -1059,7 +1059,7 @@ describe('defineHistoryService', () => {
 
               expect(history1ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/baz', search: '?qux=3'}),
-                'POP'
+                'POP',
               );
 
               history1ListenerSpy.mockClear();
@@ -1068,7 +1068,7 @@ describe('defineHistoryService', () => {
 
               expect(history1ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/bar', search: '?qux=4'}),
-                'POP'
+                'POP',
               );
             });
           });
@@ -1092,7 +1092,7 @@ describe('defineHistoryService', () => {
 
               expect(history2ListenerSpy).toHaveBeenCalledWith(
                 expect.objectContaining({pathname: '/b2'}),
-                'POP'
+                'POP',
               );
             });
           });
@@ -1119,7 +1119,7 @@ describe('defineHistoryService', () => {
                   search: '?a=1',
                   state: consumerState,
                 }),
-                'POP'
+                'POP',
               );
 
               expect(history2ListenerSpy).not.toHaveBeenCalled();
@@ -1136,7 +1136,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true}),
           );
         });
 
@@ -1147,7 +1147,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar'}, {relative: true}),
           );
         });
       });
@@ -1325,7 +1325,7 @@ describe('defineHistoryService', () => {
 
         it('changes the location and action of affected consumer histories', () => {
           const rootLocation = historyService1.createNewRootLocationForMultipleConsumers(
-            {historyKey: 'test2', location: {pathname: '/test2'}}
+            {historyKey: 'test2', location: {pathname: '/test2'}},
           );
 
           historyService1.rootHistory.push(rootLocation);
@@ -1353,7 +1353,7 @@ describe('defineHistoryService', () => {
           historyService2.history.listen(listener2);
 
           const rootLocation = historyService1.createNewRootLocationForMultipleConsumers(
-            {historyKey: 'test2', location: {pathname: '/test2'}}
+            {historyKey: 'test2', location: {pathname: '/test2'}},
           );
 
           historyService1.rootHistory.push(rootLocation);
@@ -1424,7 +1424,7 @@ describe('defineHistoryService', () => {
 
         it('changes the location and action of affected consumer histories', () => {
           const rootLocation = historyService1.createNewRootLocationForMultipleConsumers(
-            {historyKey: 'test2', location: {pathname: '/test2'}}
+            {historyKey: 'test2', location: {pathname: '/test2'}},
           );
 
           historyService1.rootHistory.replace(rootLocation);
@@ -1450,7 +1450,7 @@ describe('defineHistoryService', () => {
           historyService2.history.listen(listener2);
 
           const rootLocation = historyService1.createNewRootLocationForMultipleConsumers(
-            {historyKey: 'test2', location: {pathname: '/test2'}}
+            {historyKey: 'test2', location: {pathname: '/test2'}},
           );
 
           historyService1.rootHistory.replace(rootLocation);
@@ -1514,7 +1514,7 @@ describe('defineHistoryService', () => {
 
             expect(listenerSpy).toHaveBeenCalledWith(
               expect.objectContaining({pathname: '/'}),
-              'POP'
+              'POP',
             );
           });
         });
@@ -1538,7 +1538,7 @@ describe('defineHistoryService', () => {
         const historyService = historyServiceBinder('test1').featureService;
 
         const location = historyService.createNewRootLocationForMultipleConsumers(
-          {historyKey: 'test1', location: {pathname: '/test1', state: 42}}
+          {historyKey: 'test1', location: {pathname: '/test1', state: 42}},
         );
 
         expect(location).toMatchObject({
@@ -1560,7 +1560,7 @@ describe('defineHistoryService', () => {
           {
             historyKey: 'test2',
             location: {pathname: '/xxx', state: 'foo'},
-          }
+          },
         );
 
         expect(location).toMatchObject({
@@ -1603,11 +1603,11 @@ describe('defineHistoryService', () => {
           };
 
           historyServiceTest1.createNewRootLocationForMultipleConsumers(
-            consumerLocation
+            consumerLocation,
           );
 
           expect(
-            createNewRootLocationForMultipleConsumersMock.mock.calls
+            createNewRootLocationForMultipleConsumersMock.mock.calls,
           ).toEqual([[consumerLocation]]);
         });
 
@@ -1618,7 +1618,7 @@ describe('defineHistoryService', () => {
           };
 
           const location = historyServiceTest1.createNewRootLocationForMultipleConsumers(
-            consumerLocation
+            consumerLocation,
           );
 
           const expectedRootLocation: RootLocation = {
@@ -1655,7 +1655,7 @@ describe('defineHistoryService', () => {
         browserHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });
@@ -1667,7 +1667,7 @@ describe('defineHistoryService', () => {
     >>;
 
     let createHistoryServiceBinder: (
-      getHistoryKey?: (options: GetHistoryKeyOptions) => string
+      getHistoryKey?: (options: GetHistoryKeyOptions) => string,
     ) => FeatureServiceBinder<HistoryServiceV3>;
 
     beforeEach(() => {
@@ -1678,7 +1678,7 @@ describe('defineHistoryService', () => {
       createHistoryServiceBinder = (getHistoryKey) => {
         const sharedHistoryService = defineHistoryService(
           createRootLocationTransformer({consumerPathsQueryParamName}),
-          {getHistoryKey}
+          {getHistoryKey},
         ).create(mockEnv);
 
         return sharedHistoryService!['3.0.0'];
@@ -1702,7 +1702,7 @@ describe('defineHistoryService', () => {
           const getHistoryKeyMock = jest.fn(() => 'test-history-key');
 
           const historyServiceBinder = createHistoryServiceBinder(
-            getHistoryKeyMock
+            getHistoryKeyMock,
           );
 
           const historyBinding = historyServiceBinder(consumerId, consumerName);
@@ -1832,7 +1832,7 @@ describe('defineHistoryService', () => {
           history2.push('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(pushStateSpy).toHaveBeenCalledTimes(2);
@@ -1858,7 +1858,7 @@ describe('defineHistoryService', () => {
           history2.replace('/bar?baz=1');
 
           expect(window.location.href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?baz=1'})
+            createUrl({test1: '/foo', test2: '/bar?baz=1'}),
           );
 
           expect(replaceStateSpy).toHaveBeenCalledTimes(2);
@@ -1889,7 +1889,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.go() is not supported.'
+            'history.go() is not supported.',
           );
         });
       });
@@ -1905,7 +1905,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.back() is not supported.'
+            'history.back() is not supported.',
           );
         });
       });
@@ -1921,7 +1921,7 @@ describe('defineHistoryService', () => {
           expect(window.location.href).toBe(href);
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.forward() is not supported.'
+            'history.forward() is not supported.',
           );
         });
       });
@@ -1938,7 +1938,7 @@ describe('defineHistoryService', () => {
           expect(promptHookSpy).not.toHaveBeenCalled();
 
           expect(stubbedLogger.warn).toHaveBeenCalledWith(
-            'history.block() is not supported.'
+            'history.block() is not supported.',
           );
         });
 
@@ -2144,7 +2144,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar?a=b'}, {relative: true}),
           );
         });
 
@@ -2155,7 +2155,7 @@ describe('defineHistoryService', () => {
           const href = history2.createHref(location);
 
           expect(href).toBe(
-            createUrl({test1: '/foo', test2: '/bar'}, {relative: true})
+            createUrl({test1: '/foo', test2: '/bar'}, {relative: true}),
           );
         });
       });
@@ -2554,7 +2554,7 @@ describe('defineHistoryService', () => {
         const historyService = historyServiceBinder('test1').featureService;
 
         const location = historyService.createNewRootLocationForMultipleConsumers(
-          {historyKey: 'test1', location: {pathname: '/test1'}, state: 42}
+          {historyKey: 'test1', location: {pathname: '/test1'}, state: 42},
         );
 
         expect(location).toMatchObject({
@@ -2578,7 +2578,7 @@ describe('defineHistoryService', () => {
             historyKey: 'test2',
             location: {pathname: '/xxx'},
             state: 'foo',
-          }
+          },
         );
 
         expect(location).toMatchObject({
@@ -2621,11 +2621,11 @@ describe('defineHistoryService', () => {
           };
 
           historyServiceTest1.createNewRootLocationForMultipleConsumers(
-            consumerLocation
+            consumerLocation,
           );
 
           expect(
-            createNewRootLocationForMultipleConsumersMock.mock.calls
+            createNewRootLocationForMultipleConsumersMock.mock.calls,
           ).toEqual([[consumerLocation]]);
         });
 
@@ -2637,7 +2637,7 @@ describe('defineHistoryService', () => {
           };
 
           const location = historyServiceTest1.createNewRootLocationForMultipleConsumers(
-            consumerLocation
+            consumerLocation,
           );
 
           const expectedRootLocation: RootLocation = {
@@ -2674,7 +2674,7 @@ describe('defineHistoryService', () => {
         browserHistory.go(-1);
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'history.go() is not supported.'
+          'history.go() is not supported.',
         );
       });
     });

--- a/packages/history-service/src/__tests__/root-location-helpers.ts
+++ b/packages/history-service/src/__tests__/root-location-helpers.ts
@@ -9,13 +9,13 @@ export interface CreateUrlOptions {
 
 export const createSearch = (consumerPaths: ConsumerPaths) =>
   `?${consumerPathsQueryParamName}=${encodeURIComponent(
-    JSON.stringify(consumerPaths)
+    JSON.stringify(consumerPaths),
   )}`;
 
 export const createUrl = (
   consumerPaths: ConsumerPaths,
-  {relative, pathname = '/'}: CreateUrlOptions = {}
+  {relative, pathname = '/'}: CreateUrlOptions = {},
 ) =>
   `${relative ? '' : 'http://example.com'}${pathname}${createSearch(
-    consumerPaths
+    consumerPaths,
   )}`;

--- a/packages/history-service/src/create-root-location-transformer.ts
+++ b/packages/history-service/src/create-root-location-transformer.ts
@@ -10,13 +10,13 @@ export interface RootLocationOptions {
 export interface RootLocationTransformer {
   getConsumerPathFromRootLocation(
     rootLocation: Partial<history.Location>,
-    historyKey: string
+    historyKey: string,
   ): string | undefined;
 
   createRootLocation(
     currentRootLocation: Partial<history.Location>,
     consumerLocation: Partial<history.Location>,
-    historyKey: string
+    historyKey: string,
   ): Partial<history.Path>;
 
   createNewRootLocationForMultipleConsumers?(
@@ -39,7 +39,7 @@ function decodeConsumerPaths(encodedConsumerPaths: string): ConsumerPaths {
 export function addConsumerPath(
   encodedConsumerPaths: string | null,
   historyKey: string,
-  path: string
+  path: string,
 ): string {
   return encodeConsumerPaths({
     ...decodeConsumerPaths(encodedConsumerPaths || '{}'),
@@ -49,13 +49,13 @@ export function addConsumerPath(
 
 export function getConsumerPath(
   encodedConsumerPaths: string,
-  historyKey: string
+  historyKey: string,
 ): string {
   return decodeConsumerPaths(encodedConsumerPaths)[historyKey];
 }
 
 export function createSearchParams(
-  location: Partial<history.Path>
+  location: Partial<history.Path>,
 ): URLSearchParams {
   return new URLSearchParams(location.search);
 }
@@ -67,7 +67,7 @@ export function serializeSearchParams(searchParams: URLSearchParams): string {
 export function createRootLocationForPrimaryConsumer(
   currentRootLocation: Partial<history.Location>,
   primaryConsumerLocation: Partial<history.Path>,
-  consumerPathsQueryParamName: string
+  consumerPathsQueryParamName: string,
 ): Partial<history.Path> {
   const allSearchParams = createSearchParams(currentRootLocation);
   const newSearchParams = createSearchParams(primaryConsumerLocation);
@@ -75,8 +75,8 @@ export function createRootLocationForPrimaryConsumer(
   if (newSearchParams.has(consumerPathsQueryParamName)) {
     throw new Error(
       `Primary consumer tried to set query parameter ${JSON.stringify(
-        consumerPathsQueryParamName
-      )} which is reserverd for consumer paths.`
+        consumerPathsQueryParamName,
+      )} which is reserverd for consumer paths.`,
     );
   }
 
@@ -100,7 +100,7 @@ export function createRootLocationForOtherConsumer(
   currentRootLocation: Partial<history.Location>,
   consumerLocation: Partial<history.Path>,
   historyKey: string,
-  consumerPathsQueryParamName: string
+  consumerPathsQueryParamName: string,
 ): Partial<history.Path> {
   const allSearchParams = createSearchParams(currentRootLocation);
   const consumerPaths = allSearchParams.get(consumerPathsQueryParamName);
@@ -108,7 +108,7 @@ export function createRootLocationForOtherConsumer(
   const newConsumerPaths = addConsumerPath(
     consumerPaths,
     historyKey,
-    history.createPath(consumerLocation)
+    history.createPath(consumerLocation),
   );
 
   allSearchParams.set(consumerPathsQueryParamName, newConsumerPaths);
@@ -121,12 +121,12 @@ export function createRootLocationForOtherConsumer(
 }
 
 export function createRootLocationTransformer(
-  options: RootLocationOptions
+  options: RootLocationOptions,
 ): RootLocationTransformer {
   return {
     getConsumerPathFromRootLocation: (
       rootLocation: history.Location,
-      historyKey: string
+      historyKey: string,
     ): string | undefined => {
       const {consumerPathsQueryParamName, primaryConsumerHistoryKey} = options;
       const isPrimaryConsumer = historyKey === primaryConsumerHistoryKey;
@@ -153,7 +153,7 @@ export function createRootLocationTransformer(
     createRootLocation: (
       currentRootLocation: history.Location,
       consumerLocation: Partial<history.Path>,
-      historyKey: string
+      historyKey: string,
     ): Partial<history.Path> => {
       const {consumerPathsQueryParamName, primaryConsumerHistoryKey} = options;
       const isPrimaryConsumer = historyKey === primaryConsumerHistoryKey;
@@ -162,7 +162,7 @@ export function createRootLocationTransformer(
         return createRootLocationForPrimaryConsumer(
           currentRootLocation,
           consumerLocation,
-          consumerPathsQueryParamName
+          consumerPathsQueryParamName,
         );
       }
 
@@ -170,7 +170,7 @@ export function createRootLocationTransformer(
         currentRootLocation,
         consumerLocation,
         historyKey,
-        consumerPathsQueryParamName
+        consumerPathsQueryParamName,
       );
     },
   };

--- a/packages/history-service/src/history-v4.ts
+++ b/packages/history-service/src/history-v4.ts
@@ -14,17 +14,17 @@ export interface History<HistoryLocationState = LocationState> {
   location: Location<HistoryLocationState>;
   push(
     location: Path | LocationDescriptor<HistoryLocationState>,
-    state?: HistoryLocationState
+    state?: HistoryLocationState,
   ): void;
   replace(
     location: Path | LocationDescriptor<HistoryLocationState>,
-    state?: HistoryLocationState
+    state?: HistoryLocationState,
   ): void;
   go(n: number): void;
   goBack(): void;
   goForward(): void;
   block(
-    prompt?: boolean | string | TransitionPromptHook<HistoryLocationState>
+    prompt?: boolean | string | TransitionPromptHook<HistoryLocationState>,
   ): UnregisterCallback;
   listen(listener: LocationListener<HistoryLocationState>): UnregisterCallback;
   createHref(location: LocationDescriptorObject<HistoryLocationState>): Href;
@@ -52,7 +52,7 @@ export type LocationDescriptor<S = LocationState> =
 export type LocationKey = string;
 export type LocationListener<S = LocationState> = (
   location: Location<S>,
-  action: Action
+  action: Action,
 ) => void;
 
 export type LocationState = unknown;
@@ -61,11 +61,11 @@ export type Pathname = string;
 export type Search = string;
 export type TransitionHook<S = LocationState> = (
   location: Location<S>,
-  callback: (result: any) => void
+  callback: (result: any) => void,
 ) => any;
 export type TransitionPromptHook<S = LocationState> = (
   location: Location<S>,
-  action: Action
+  action: Action,
 ) => string | false | void;
 export type Hash = string;
 export type Href = string;

--- a/packages/history-service/src/index.ts
+++ b/packages/history-service/src/index.ts
@@ -142,7 +142,7 @@ export interface HistoryServiceDefinitionOptions {
 
 export function defineHistoryService(
   rootLocationTransformer: RootLocationTransformer,
-  options: HistoryServiceDefinitionOptions = {}
+  options: HistoryServiceDefinitionOptions = {},
 ): FeatureServiceProviderDefinition<
   SharedHistoryService,
   HistoryServiceDependencies
@@ -167,7 +167,7 @@ export function defineHistoryService(
 
       const historyMultiplexers = createHistoryMultiplexers(
         context,
-        rootLocationTransformer
+        rootLocationTransformer,
       );
 
       return {

--- a/packages/history-service/src/internal/browser-consumer-history.ts
+++ b/packages/history-service/src/internal/browser-consumer-history.ts
@@ -12,14 +12,14 @@ export class BrowserConsumerHistory extends ConsumerHistory {
   public constructor(
     context: HistoryServiceContext,
     historyKey: string,
-    historyMultiplexer: HistoryMultiplexer
+    historyMultiplexer: HistoryMultiplexer,
   ) {
     super(context, historyKey, historyMultiplexer);
 
     this.browserUnregister = historyMultiplexer.listenForRootLocationChange(
       (action) => {
         this.handleRootLocationChange(action);
-      }
+      },
     );
 
     this.listen = this.listen.bind(this);
@@ -62,7 +62,7 @@ export class BrowserConsumerHistory extends ConsumerHistory {
 
   private handleRootLocationChange(action: history.Action): void {
     const location = this.historyMultiplexer.getConsumerLocation(
-      this.historyKey
+      this.historyKey,
     );
 
     if (this.matches(location)) {

--- a/packages/history-service/src/internal/consumer-history.ts
+++ b/packages/history-service/src/internal/consumer-history.ts
@@ -11,7 +11,7 @@ export abstract class ConsumerHistory implements history.History {
   public constructor(
     protected readonly context: HistoryServiceContext,
     protected readonly historyKey: string,
-    protected readonly historyMultiplexer: HistoryMultiplexer
+    protected readonly historyMultiplexer: HistoryMultiplexer,
   ) {
     const {
       pathname,
@@ -78,7 +78,7 @@ export abstract class ConsumerHistory implements history.History {
   public createHref(to: history.To): string {
     return this.historyMultiplexer.createHref(
       this.historyKey,
-      createHistoryPath(to, history.createPath(this.location))
+      createHistoryPath(to, history.createPath(this.location)),
     );
   }
 

--- a/packages/history-service/src/internal/create-history-multiplexers.ts
+++ b/packages/history-service/src/internal/create-history-multiplexers.ts
@@ -10,7 +10,7 @@ export interface HistoryMultiplexers {
 
 export function createHistoryMultiplexers(
   context: HistoryServiceContext,
-  rootLocationTransformer: RootLocationTransformer
+  rootLocationTransformer: RootLocationTransformer,
 ): HistoryMultiplexers {
   let browserHistoryMultiplexer: HistoryMultiplexer | undefined;
   let staticHistoryMultiplexer: HistoryMultiplexer | undefined;
@@ -20,7 +20,7 @@ export function createHistoryMultiplexers(
       if (!browserHistoryMultiplexer) {
         browserHistoryMultiplexer = new HistoryMultiplexer(
           history.createBrowserHistory(),
-          rootLocationTransformer
+          rootLocationTransformer,
         );
       }
 
@@ -31,7 +31,7 @@ export function createHistoryMultiplexers(
       if (!staticHistoryMultiplexer) {
         if (!context.serverRequest) {
           throw new Error(
-            'Static history can not be created without a server request.'
+            'Static history can not be created without a server request.',
           );
         }
 
@@ -40,7 +40,7 @@ export function createHistoryMultiplexers(
             initialEntries: [createPathFromUrl(context.serverRequest.url)],
             initialIndex: 0,
           }),
-          rootLocationTransformer
+          rootLocationTransformer,
         );
       }
 

--- a/packages/history-service/src/internal/create-history-path.ts
+++ b/packages/history-service/src/internal/create-history-path.ts
@@ -3,13 +3,13 @@ import resolvePathname from 'resolve-pathname';
 
 export function createHistoryPath(
   to: history.To,
-  currentPathname: string = ``
+  currentPathname: string = ``,
 ): history.Path {
   const path = typeof to === 'string' ? to : history.createPath(to);
 
   /* istanbul ignore next */
   const {pathname = '', search = '', hash = ''} = history.parsePath(
-    path.startsWith('/') ? path : resolvePathname(path, currentPathname)
+    path.startsWith('/') ? path : resolvePathname(path, currentPathname),
   );
 
   return {pathname, search, hash};

--- a/packages/history-service/src/internal/create-history-service-v1-binder.ts
+++ b/packages/history-service/src/internal/create-history-service-v1-binder.ts
@@ -15,13 +15,13 @@ export interface CreateHistoryServiceV1BinderOptions {
 export function createHistoryServiceV1Binder(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  options: CreateHistoryServiceV1BinderOptions
+  options: CreateHistoryServiceV1BinderOptions,
 ): FeatureServiceBinder<HistoryServiceV1> {
   const {getHistoryKey} = options;
 
   return (
     consumerId,
-    consumerName
+    consumerName,
   ): FeatureServiceBinding<HistoryServiceV1> => {
     const historyKey = getHistoryKey({consumerId, consumerName});
 
@@ -34,14 +34,14 @@ export function createHistoryServiceV1Binder(
         if (browserConsumerHistory) {
           context.logger.warn(
             `createBrowserHistory was called multiple times by consumer ${JSON.stringify(
-              consumerId
-            )}. Returning the same history instance as before.`
+              consumerId,
+            )}. Returning the same history instance as before.`,
           );
         } else {
           const browserConsumerHistoryV5 = new BrowserConsumerHistory(
             context,
             historyKey,
-            historyMultiplexers.browserHistoryMultiplexer
+            historyMultiplexers.browserHistoryMultiplexer,
           );
 
           browserConsumerHistoryDestroy = () =>
@@ -49,7 +49,7 @@ export function createHistoryServiceV1Binder(
 
           browserConsumerHistory = createHistoryV4Adapter(
             context,
-            browserConsumerHistoryV5
+            browserConsumerHistoryV5,
           );
         }
 
@@ -60,8 +60,8 @@ export function createHistoryServiceV1Binder(
         if (staticConsumerHistory) {
           context.logger.warn(
             `createStaticHistory was called multiple times by consumer ${JSON.stringify(
-              consumerId
-            )}. Returning the same history instance as before.`
+              consumerId,
+            )}. Returning the same history instance as before.`,
           );
         } else {
           staticConsumerHistory = createHistoryV4Adapter(
@@ -69,8 +69,8 @@ export function createHistoryServiceV1Binder(
             new StaticConsumerHistory(
               context,
               historyKey,
-              historyMultiplexers.staticHistoryMultiplexer
-            )
+              historyMultiplexers.staticHistoryMultiplexer,
+            ),
           );
         }
 

--- a/packages/history-service/src/internal/create-history-service-v2-binder.ts
+++ b/packages/history-service/src/internal/create-history-service-v2-binder.ts
@@ -18,7 +18,7 @@ function createHistoryServiceV2(
   context: HistoryServiceContext,
   historyKey: string,
   consumerHistory: ConsumerHistory,
-  historyMultiplexer: HistoryMultiplexer
+  historyMultiplexer: HistoryMultiplexer,
 ): HistoryServiceV2 {
   return {
     historyKey,
@@ -35,8 +35,8 @@ function createHistoryServiceV2(
             historyKey: otherHistoryKey,
             location: {pathname, search, hash},
             state,
-          })
-        )
+          }),
+        ),
       ),
   };
 }
@@ -44,12 +44,12 @@ function createHistoryServiceV2(
 function createBrowserHistoryServiceV2Binding(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  historyKey: string
+  historyKey: string,
 ): FeatureServiceBinding<HistoryServiceV2> {
   const consumerHistory = new BrowserConsumerHistory(
     context,
     historyKey,
-    historyMultiplexers.browserHistoryMultiplexer
+    historyMultiplexers.browserHistoryMultiplexer,
   );
 
   return {
@@ -57,7 +57,7 @@ function createBrowserHistoryServiceV2Binding(
       context,
       historyKey,
       consumerHistory,
-      historyMultiplexers.browserHistoryMultiplexer
+      historyMultiplexers.browserHistoryMultiplexer,
     ),
 
     unbind: () => {
@@ -69,12 +69,12 @@ function createBrowserHistoryServiceV2Binding(
 function createStaticHistoryServiceV2Binding(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  historyKey: string
+  historyKey: string,
 ): FeatureServiceBinding<HistoryServiceV2> {
   const consumerHistory = new StaticConsumerHistory(
     context,
     historyKey,
-    historyMultiplexers.staticHistoryMultiplexer
+    historyMultiplexers.staticHistoryMultiplexer,
   );
 
   return {
@@ -82,7 +82,7 @@ function createStaticHistoryServiceV2Binding(
       context,
       historyKey,
       consumerHistory,
-      historyMultiplexers.staticHistoryMultiplexer
+      historyMultiplexers.staticHistoryMultiplexer,
     ),
   };
 }
@@ -90,13 +90,13 @@ function createStaticHistoryServiceV2Binding(
 export function createHistoryServiceV2Binder(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  options: CreateHistoryServiceV2BinderOptions
+  options: CreateHistoryServiceV2BinderOptions,
 ): FeatureServiceBinder<HistoryServiceV2> {
   const {mode, getHistoryKey} = options;
 
   return (
     consumerId,
-    consumerName
+    consumerName,
   ): FeatureServiceBinding<HistoryServiceV2> => {
     const historyKey = getHistoryKey({consumerId, consumerName});
 
@@ -104,12 +104,12 @@ export function createHistoryServiceV2Binder(
       ? createBrowserHistoryServiceV2Binding(
           context,
           historyMultiplexers,
-          historyKey
+          historyKey,
         )
       : createStaticHistoryServiceV2Binding(
           context,
           historyMultiplexers,
-          historyKey
+          historyKey,
         );
   };
 }

--- a/packages/history-service/src/internal/create-history-service-v3-binder.ts
+++ b/packages/history-service/src/internal/create-history-service-v3-binder.ts
@@ -20,7 +20,7 @@ export interface GetHistoryKeyOptions {
 function createHistoryServiceV3(
   historyKey: string,
   consumerHistory: history.History,
-  historyMultiplexer: HistoryMultiplexer
+  historyMultiplexer: HistoryMultiplexer,
 ): HistoryServiceV3 {
   return {
     historyKey,
@@ -29,7 +29,7 @@ function createHistoryServiceV3(
 
     createNewRootLocationForMultipleConsumers: (...consumerLocations) =>
       historyMultiplexer.createNewRootLocationForMultipleConsumers(
-        ...consumerLocations
+        ...consumerLocations,
       ),
   };
 }
@@ -37,19 +37,19 @@ function createHistoryServiceV3(
 function createBrowserHistoryServiceV3Binding(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  historyKey: string
+  historyKey: string,
 ): FeatureServiceBinding<HistoryServiceV3> {
   const consumerHistory = new BrowserConsumerHistory(
     context,
     historyKey,
-    historyMultiplexers.browserHistoryMultiplexer
+    historyMultiplexers.browserHistoryMultiplexer,
   );
 
   return {
     featureService: createHistoryServiceV3(
       historyKey,
       consumerHistory,
-      historyMultiplexers.browserHistoryMultiplexer
+      historyMultiplexers.browserHistoryMultiplexer,
     ),
 
     unbind: () => {
@@ -61,19 +61,19 @@ function createBrowserHistoryServiceV3Binding(
 function createStaticHistoryServiceV3Binding(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  consumerId: string
+  consumerId: string,
 ): FeatureServiceBinding<HistoryServiceV3> {
   const consumerHistory = new StaticConsumerHistory(
     context,
     consumerId,
-    historyMultiplexers.staticHistoryMultiplexer
+    historyMultiplexers.staticHistoryMultiplexer,
   );
 
   return {
     featureService: createHistoryServiceV3(
       consumerId,
       consumerHistory,
-      historyMultiplexers.staticHistoryMultiplexer
+      historyMultiplexers.staticHistoryMultiplexer,
     ),
   };
 }
@@ -81,13 +81,13 @@ function createStaticHistoryServiceV3Binding(
 export function createHistoryServiceV3Binder(
   context: HistoryServiceContext,
   historyMultiplexers: HistoryMultiplexers,
-  options: CreateHistoryServiceV3BinderOptions
+  options: CreateHistoryServiceV3BinderOptions,
 ): FeatureServiceBinder<HistoryServiceV3> {
   const {mode, getHistoryKey} = options;
 
   return (
     consumerId,
-    consumerName
+    consumerName,
   ): FeatureServiceBinding<HistoryServiceV3> => {
     const historyKey = getHistoryKey({consumerId, consumerName});
 
@@ -95,12 +95,12 @@ export function createHistoryServiceV3Binder(
       ? createBrowserHistoryServiceV3Binding(
           context,
           historyMultiplexers,
-          historyKey
+          historyKey,
         )
       : createStaticHistoryServiceV3Binding(
           context,
           historyMultiplexers,
-          historyKey
+          historyKey,
         );
   };
 }

--- a/packages/history-service/src/internal/create-history-v4-adapter.ts
+++ b/packages/history-service/src/internal/create-history-v4-adapter.ts
@@ -4,7 +4,7 @@ import {HistoryServiceContext} from './history-service-context';
 
 export function createHistoryV4Adapter(
   context: HistoryServiceContext,
-  history: History
+  history: History,
 ): historyV4.History {
   return {
     get length(): number {

--- a/packages/history-service/src/internal/history-multiplexer.ts
+++ b/packages/history-service/src/internal/history-multiplexer.ts
@@ -24,7 +24,7 @@ export class HistoryMultiplexer {
 
   public constructor(
     public readonly rootHistory: history.History,
-    public readonly rootLocationTransformer: RootLocationTransformer
+    public readonly rootLocationTransformer: RootLocationTransformer,
   ) {
     this.rootHistoryV2 = {
       get length(): number {
@@ -56,10 +56,10 @@ export class HistoryMultiplexer {
       },
 
       listen(
-        listener: historyV4.LocationListener
+        listener: historyV4.LocationListener,
       ): historyV4.UnregisterCallback {
         return rootHistory.listen(({location, action}) =>
-          listener(location, action)
+          listener(location, action),
         );
       },
     };
@@ -72,7 +72,7 @@ export class HistoryMultiplexer {
   public push(historyKey: string, consumerLocation: history.Location): void {
     const {pathname, search, hash, state} = this.createRootLocation(
       historyKey,
-      consumerLocation
+      consumerLocation,
     );
 
     this.rootHistory.push({pathname, search, hash}, state);
@@ -81,7 +81,7 @@ export class HistoryMultiplexer {
   public replace(historyKey: string, consumerLocation: history.Location): void {
     const {pathname, search, hash, state} = this.createRootLocation(
       historyKey,
-      consumerLocation
+      consumerLocation,
     );
 
     this.rootHistory.replace({pathname, search, hash}, state);
@@ -89,11 +89,11 @@ export class HistoryMultiplexer {
 
   public createHref(
     historyKey: string,
-    consumerLocation: history.Path
+    consumerLocation: history.Path,
   ): string {
     const {pathname, search, hash} = this.createRootLocation(
       historyKey,
-      consumerLocation
+      consumerLocation,
     );
 
     return this.rootHistory.createHref({pathname, search, hash});
@@ -103,7 +103,7 @@ export class HistoryMultiplexer {
     const consumerPath =
       this.rootLocationTransformer.getConsumerPathFromRootLocation(
         this.rootLocation,
-        historyKey
+        historyKey,
       ) || '/';
 
     const {state, key} = this.rootLocation.state?.[historyKey] || {
@@ -119,7 +119,7 @@ export class HistoryMultiplexer {
   }
 
   public listenForRootLocationChange(
-    listener: (action: history.Action) => void
+    listener: (action: history.Action) => void,
   ): () => void {
     return this.rootHistory.listen(({action}) => {
       listener(action);
@@ -135,14 +135,14 @@ export class HistoryMultiplexer {
       this.rootLocationTransformer.createNewRootLocationForMultipleConsumers
     ) {
       newRootLocation = this.rootLocationTransformer.createNewRootLocationForMultipleConsumers(
-        ...consumerLocations
+        ...consumerLocations,
       );
     } else {
       for (const consumerLocation of consumerLocations) {
         newRootLocation = this.rootLocationTransformer.createRootLocation(
           newRootLocation,
           consumerLocation.location,
-          consumerLocation.historyKey
+          consumerLocation.historyKey,
         );
       }
     }
@@ -158,12 +158,12 @@ export class HistoryMultiplexer {
 
   private createRootLocation(
     historyKey: string,
-    consumerLocation: Partial<history.Location>
+    consumerLocation: Partial<history.Location>,
   ): Omit<RootLocation, 'key'> {
     const newRootLocation = this.rootLocationTransformer.createRootLocation(
       this.rootLocation,
       consumerLocation,
-      historyKey
+      historyKey,
     );
 
     const {state, key = createKey()} = consumerLocation;

--- a/packages/history-service/src/internal/history-service-context.ts
+++ b/packages/history-service/src/internal/history-service-context.ts
@@ -8,7 +8,7 @@ export interface HistoryServiceContext {
 }
 
 export function createHistoryServiceContext(
-  featureServices: HistoryServiceDependencies
+  featureServices: HistoryServiceDependencies,
 ): HistoryServiceContext {
   const logger = featureServices['s2:logger'] || console;
   const serverRequest = featureServices['s2:server-request'];

--- a/packages/history-service/src/internal/static-consumer-history.ts
+++ b/packages/history-service/src/internal/static-consumer-history.ts
@@ -7,7 +7,7 @@ export class StaticConsumerHistory extends ConsumerHistory {
   public constructor(
     context: HistoryServiceContext,
     historyKey: string,
-    historyMultiplexer: HistoryMultiplexer
+    historyMultiplexer: HistoryMultiplexer,
   ) {
     super(context, historyKey, historyMultiplexer);
 

--- a/packages/logger/src/__tests__/index.test.ts
+++ b/packages/logger/src/__tests__/index.test.ts
@@ -71,11 +71,11 @@ describe('defineLogger', () => {
             logger[method]('test');
           } catch (error) {
             expect((error as Error).stack).toMatch(
-              /logger\/src\/__tests__\/index.test\.(js|ts)/
+              /logger\/src\/__tests__\/index.test\.(js|ts)/,
             );
 
             expect((error as Error).stack).not.toMatch(
-              /logger\/src\/index\.(js|ts)/
+              /logger\/src\/index\.(js|ts)/,
             );
           }
         });

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -13,11 +13,11 @@ export interface SharedLogger extends SharedFeatureService {
 
 export type ConsumerLoggerCreator = (
   consumerId: string,
-  consumerName?: string
+  consumerName?: string,
 ) => Logger;
 
 export function defineLogger(
-  createConsumerLogger: ConsumerLoggerCreator = () => console
+  createConsumerLogger: ConsumerLoggerCreator = () => console,
 ): FeatureServiceProviderDefinition<SharedLogger> {
   return {
     id: 's2:logger',

--- a/packages/module-loader-commonjs/src/__tests__/index.test.ts
+++ b/packages/module-loader-commonjs/src/__tests__/index.test.ts
@@ -52,7 +52,7 @@ describe('createCommonJsModuleLoader', () => {
 
     const loadCommonJsModuleWithExternals = createCommonJsModuleLoader(
       {foo: () => 42},
-      init
+      init,
     );
 
     const loadedModule = await loadCommonJsModuleWithExternals(url);

--- a/packages/module-loader-commonjs/src/index.ts
+++ b/packages/module-loader-commonjs/src/index.ts
@@ -18,7 +18,7 @@ export interface Externals {
  */
 export function createCommonJsModuleLoader(
   externals: Externals = {},
-  requestInit?: RequestInit
+  requestInit?: RequestInit,
 ): (url: string) => Promise<unknown> {
   return async (url: string): Promise<unknown> => {
     const response = await fetch(url, requestInit);
@@ -31,10 +31,10 @@ export function createCommonJsModuleLoader(
       'exports',
       'require',
       `${source}
-      //# sourceURL=${url}`
+      //# sourceURL=${url}`,
     )(mod, mod.exports, (dep: string) =>
       // tslint:disable-next-line:no-eval https://stackoverflow.com/a/41063795/10385541
-      externals.hasOwnProperty(dep) ? externals[dep] : eval('require')(dep)
+      externals.hasOwnProperty(dep) ? externals[dep] : eval('require')(dep),
     );
 
     return mod.exports;
@@ -48,5 +48,5 @@ export function createCommonJsModuleLoader(
  * the module can not be loaded.
  */
 export const loadCommonJsModule: (
-  url: string
+  url: string,
 ) => Promise<unknown> = createCommonJsModuleLoader();

--- a/packages/module-loader-federation/src/index.ts
+++ b/packages/module-loader-federation/src/index.ts
@@ -30,7 +30,7 @@ async function loadComponent(): Promise<unknown> {
 
   if (!container) {
     throw new Error(
-      `The name in the ModuleFederationPlugin must be "__feature_hub_feature_app_module_container__".`
+      `The name in the ModuleFederationPlugin must be "__feature_hub_feature_app_module_container__".`,
     );
   }
 

--- a/packages/react/src/__tests__/feature-app-container.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.node.test.tsx
@@ -58,7 +58,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
         value={{featureAppManager: mockFeatureAppManager}}
       >
         {node}
-      </FeatureHubContextProvider>
+      </FeatureHubContextProvider>,
     );
 
   for (const invalidFeatureApp of [
@@ -69,7 +69,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
     {render: 'foo'},
   ]) {
     describe(`when an invalid Feature App (${JSON.stringify(
-      invalidFeatureApp
+      invalidFeatureApp,
     )}) is created`, () => {
       beforeEach(() => {
         mockFeatureAppScope = {
@@ -80,14 +80,14 @@ describe('FeatureAppContainer (on Node.js)', () => {
 
       it('logs an error', () => {
         const expectedError = new Error(
-          'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.'
+          'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.',
         );
 
         renderWithFeatureHubContext(
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expectConsoleErrorCalls([[expectedError]]);
@@ -111,7 +111,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
         <FeatureAppContainer
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
-        />
+        />,
       );
 
       expectConsoleErrorCalls([[mockError]]);
@@ -139,7 +139,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
         <FeatureAppContainer
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
-        />
+        />,
       );
 
       expectConsoleErrorCalls([[mockError]]);
@@ -183,7 +183,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
           children={children}
-        />
+        />,
       );
 
       expect(children).toHaveBeenCalledTimes(1);
@@ -202,7 +202,7 @@ describe('FeatureAppContainer (on Node.js)', () => {
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
           children={children}
-        />
+        />,
       );
 
       expect(children).toHaveBeenCalledTimes(1);

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -32,7 +32,7 @@ describe('FeatureAppContainer', () => {
   const noErrorBoundaryConsoleErrorCalls = [
     [
       expect.stringContaining(
-        'Consider adding an error boundary to your tree to customize error handling behavior.'
+        'Consider adding an error boundary to your tree to customize error handling behavior.',
       ),
     ],
   ];
@@ -40,7 +40,7 @@ describe('FeatureAppContainer', () => {
   const usingTestErrorBoundaryConsoleErrorCalls = [
     [
       expect.stringContaining(
-        'React will try to recreate this component tree from scratch using the error boundary you provided, TestErrorBoundary.'
+        'React will try to recreate this component tree from scratch using the error boundary you provided, TestErrorBoundary.',
       ),
     ],
   ];
@@ -85,12 +85,12 @@ describe('FeatureAppContainer', () => {
         <FeatureAppContainer
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
-        />
-      )
+        />,
+      ),
     ).toThrowError(
       new Error(
-        'No Feature Hub context was provided! There are two possible causes: 1.) No FeatureHubContextProvider was rendered in the React tree. 2.) A Feature App that renders itself a FeatureAppLoader or a FeatureAppContainer did not declare @feature-hub/react as an external package.'
-      )
+        'No Feature Hub context was provided! There are two possible causes: 1.) No FeatureHubContextProvider was rendered in the React tree. 2.) A Feature App that renders itself a FeatureAppLoader or a FeatureAppContainer did not declare @feature-hub/react as an external package.',
+      ),
     );
 
     expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
@@ -104,7 +104,7 @@ describe('FeatureAppContainer', () => {
     }: {
       customLogger?: boolean;
       testRendererOptions?: TestRenderer.TestRendererOptions;
-    } = {}
+    } = {},
   ) =>
     TestRenderer.create(
       <FeatureHubContextProvider
@@ -115,7 +115,7 @@ describe('FeatureAppContainer', () => {
       >
         {node}
       </FeatureHubContextProvider>,
-      testRendererOptions
+      testRendererOptions,
     );
 
   it('calls the Feature App manager with the given featureAppDefinition, featureAppId, config, baseUrl, beforeCreate callback, and done callback', () => {
@@ -130,7 +130,7 @@ describe('FeatureAppContainer', () => {
         baseUrl="/base"
         beforeCreate={mockBeforeCreate}
         done={mockDone}
-      />
+      />,
     );
 
     const expectedOptions: FeatureAppScopeOptions<{}, string> = {
@@ -160,7 +160,7 @@ describe('FeatureAppContainer', () => {
         <FeatureAppContainer
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
-        />
+        />,
       );
 
       expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
@@ -175,7 +175,7 @@ describe('FeatureAppContainer', () => {
         const children = jest.fn(
           ({featureAppNode}: CustomFeatureAppRenderingParams) => (
             <div id="children-wrap">{featureAppNode}</div>
-          )
+          ),
         );
 
         const testRenderer = renderWithFeatureHubContext(
@@ -183,7 +183,7 @@ describe('FeatureAppContainer', () => {
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
             children={children}
-          />
+          />,
         );
 
         expect(children).toHaveBeenCalledTimes(1);
@@ -240,7 +240,7 @@ describe('FeatureAppContainer', () => {
             featureAppId="parentTestId"
             featureAppName="parentTestName"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(mockCreateFeatureAppScope.mock.calls).toEqual([
@@ -291,7 +291,7 @@ describe('FeatureAppContainer', () => {
             <FeatureAppContainer
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
-            />
+            />,
           );
         }).not.toThrow();
       });
@@ -301,7 +301,7 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(logger.error.mock.calls).toEqual([[mockError]]);
@@ -316,7 +316,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
-            />
+            />,
           );
 
           expect(onError.mock.calls).toEqual([[mockError]]);
@@ -328,7 +328,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={jest.fn()}
-            />
+            />,
           );
 
           expect(logger.error).not.toHaveBeenCalled();
@@ -350,8 +350,8 @@ describe('FeatureAppContainer', () => {
                   onError={() => {
                     throw onErrorMockError;
                   }}
-                />
-              )
+                />,
+              ),
             ).toThrowError(onErrorMockError);
 
             expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
@@ -362,7 +362,7 @@ describe('FeatureAppContainer', () => {
       describe('with a children function provided', () => {
         it('calls the children function with the error and loading=false', () => {
           const children = jest.fn(
-            (_: CustomFeatureAppRenderingParams) => null
+            (_: CustomFeatureAppRenderingParams) => null,
           );
 
           renderWithFeatureHubContext(
@@ -370,7 +370,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               children={children}
-            />
+            />,
           );
 
           const expected: CustomFeatureAppRenderingParams = {
@@ -388,7 +388,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               children={() => 'Custom Error UI'}
-            />
+            />,
           );
 
           expect(testRenderer.toJSON()).toBe('Custom Error UI');
@@ -401,7 +401,7 @@ describe('FeatureAppContainer', () => {
               children={() => 'loading UI'}
               logger={logger}
               featureAppManager={mockFeatureAppManager}
-            />
+            />,
           );
 
           expect(testRenderer.toJSON()).toBe('loading UI');
@@ -423,8 +423,8 @@ describe('FeatureAppContainer', () => {
                   children={() => {
                     throw childrenMockError;
                   }}
-                />
-              )
+                />,
+              ),
             ).toThrowError(childrenMockError);
 
             expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
@@ -463,7 +463,7 @@ describe('FeatureAppContainer', () => {
             <FeatureAppContainer
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
-            />
+            />,
           );
         }).not.toThrow();
       });
@@ -473,7 +473,7 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(logger.error.mock.calls).toEqual([[mockError]]);
@@ -488,7 +488,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
-            />
+            />,
           );
 
           expect(onError.mock.calls).toEqual([[mockError]]);
@@ -500,7 +500,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
               onError={jest.fn()}
-            />
+            />,
           );
 
           expect(logger.error).not.toHaveBeenCalled();
@@ -522,8 +522,8 @@ describe('FeatureAppContainer', () => {
                   onError={() => {
                     throw onErrorMockError;
                   }}
-                />
-              )
+                />,
+              ),
             ).toThrowError(onErrorMockError);
 
             expectConsoleErrorCalls([
@@ -541,7 +541,7 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(mockFeatureAppScope.release).not.toHaveBeenCalled();
@@ -567,7 +567,7 @@ describe('FeatureAppContainer', () => {
             <FeatureAppContainer
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
-            />
+            />,
           );
 
           testRenderer.unmount();
@@ -584,7 +584,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={onError}
-              />
+              />,
             );
 
             testRenderer.unmount();
@@ -598,7 +598,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={jest.fn()}
-              />
+              />,
             );
 
             testRenderer.unmount();
@@ -621,11 +621,11 @@ describe('FeatureAppContainer', () => {
                   onError={() => {
                     throw onErrorMockError;
                   }}
-                />
+                />,
               );
 
               expect(() => testRenderer.unmount()).toThrowError(
-                onErrorMockError
+                onErrorMockError,
               );
 
               expectConsoleErrorCalls([
@@ -678,7 +678,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 logger={logger}
                 featureAppManager={mockFeatureAppManager}
-              />
+              />,
             );
 
             expect(testRenderer.getInstance()).toBeNull();
@@ -691,7 +691,7 @@ describe('FeatureAppContainer', () => {
               <FeatureAppContainer
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
-              />
+              />,
             );
 
             expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
@@ -715,7 +715,7 @@ describe('FeatureAppContainer', () => {
 
           beforeEach(() => {
             loadingPromiseMockError = new Error(
-              'loading promise rejected with error'
+              'loading promise rejected with error',
             );
           });
 
@@ -725,7 +725,7 @@ describe('FeatureAppContainer', () => {
                 <FeatureAppContainer
                   featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
-                />
+                />,
               );
 
               await rejectLoadingPromise(loadingPromiseMockError);
@@ -745,7 +745,7 @@ describe('FeatureAppContainer', () => {
                   featureAppId="testId"
                   featureAppDefinition={mockFeatureAppDefinition}
                   onError={onError}
-                />
+                />,
               );
 
               await rejectLoadingPromise(loadingPromiseMockError);
@@ -762,7 +762,7 @@ describe('FeatureAppContainer', () => {
                     featureAppId="testId"
                     featureAppDefinition={mockFeatureAppDefinition}
                     onError={onError}
-                  />
+                  />,
                 );
 
                 expect(onError.mock.calls).toEqual([]);
@@ -796,7 +796,7 @@ describe('FeatureAppContainer', () => {
                         throw onErrorMockError;
                       }}
                     />
-                  </TestErrorBoundary>
+                  </TestErrorBoundary>,
                 );
 
                 expectConsoleErrorCalls([]);
@@ -808,7 +808,7 @@ describe('FeatureAppContainer', () => {
                 expect(testRenderer.toJSON()).toBe('test error boundary');
 
                 expectConsoleErrorCalls(
-                  usingTestErrorBoundaryConsoleErrorCalls
+                  usingTestErrorBoundaryConsoleErrorCalls,
                 );
               });
 
@@ -823,7 +823,7 @@ describe('FeatureAppContainer', () => {
                       featureAppId="testId"
                       featureAppDefinition={mockFeatureAppDefinition}
                       onError={onError}
-                    />
+                    />,
                   );
 
                   expect(onError.mock.calls).toEqual([]);
@@ -848,7 +848,7 @@ describe('FeatureAppContainer', () => {
         describe('when promise resolves', () => {
           it('initially passes loading=true to children function, then loading=false', async () => {
             const children = jest.fn(
-              (_: CustomFeatureAppRenderingParams) => null
+              (_: CustomFeatureAppRenderingParams) => null,
             );
 
             renderWithFeatureHubContext(
@@ -856,7 +856,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 children={children}
-              />
+              />,
             );
 
             expect(children).toHaveBeenCalledTimes(1);
@@ -874,7 +874,7 @@ describe('FeatureAppContainer', () => {
             const children = jest.fn(
               ({loading}: CustomFeatureAppRenderingParams) => (
                 <span>{loading ? 'is loading' : 'not loading'}</span>
-              )
+              ),
             );
 
             const testRenderer = renderWithFeatureHubContext(
@@ -882,7 +882,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 children={children}
-              />
+              />,
             );
 
             expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
@@ -910,7 +910,7 @@ describe('FeatureAppContainer', () => {
 
           it('initially passes loading=true to children, then loading=false', async () => {
             const children = jest.fn(
-              (_: CustomFeatureAppRenderingParams) => null
+              (_: CustomFeatureAppRenderingParams) => null,
             );
 
             renderWithFeatureHubContext(
@@ -918,7 +918,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 children={children}
-              />
+              />,
             );
 
             expect(children).toHaveBeenCalledTimes(1);
@@ -934,7 +934,7 @@ describe('FeatureAppContainer', () => {
 
           it('calls children with rejection error', async () => {
             const children = jest.fn(
-              (_: CustomFeatureAppRenderingParams) => null
+              (_: CustomFeatureAppRenderingParams) => null,
             );
 
             renderWithFeatureHubContext(
@@ -942,7 +942,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 children={children}
-              />
+              />,
             );
 
             expect(children).toHaveBeenCalledTimes(1);
@@ -958,7 +958,7 @@ describe('FeatureAppContainer', () => {
 
           it(`doesn't pass featureAppNode to children after rejection`, async () => {
             const children = jest.fn(
-              (_: CustomFeatureAppRenderingParams) => null
+              (_: CustomFeatureAppRenderingParams) => null,
             );
 
             renderWithFeatureHubContext(
@@ -966,7 +966,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 children={children}
-              />
+              />,
             );
 
             expect(children).toHaveBeenCalledTimes(1);
@@ -993,7 +993,7 @@ describe('FeatureAppContainer', () => {
             <FeatureAppContainer
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
-            />
+            />,
           );
 
           testRenderer.unmount();
@@ -1033,13 +1033,13 @@ describe('FeatureAppContainer', () => {
               },
             }),
           },
-        }
+        },
       );
 
       expect(testRenderer.toJSON()).toMatchInlineSnapshot(`<div />`);
 
       expect(mockSetInnerHtml).toHaveBeenCalledWith(
-        'This is the DOM Feature App.'
+        'This is the DOM Feature App.',
       );
     });
 
@@ -1050,7 +1050,7 @@ describe('FeatureAppContainer', () => {
         const children = jest.fn(
           ({featureAppNode}: CustomFeatureAppRenderingParams) => (
             <div id="children-wrap">{featureAppNode}</div>
-          )
+          ),
         );
 
         const testRenderer = renderWithFeatureHubContext(
@@ -1067,7 +1067,7 @@ describe('FeatureAppContainer', () => {
                 },
               }),
             },
-          }
+          },
         );
 
         expect(children).toHaveBeenCalledTimes(1);
@@ -1080,7 +1080,7 @@ describe('FeatureAppContainer', () => {
         `);
 
         expect(mockSetInnerHtml).toHaveBeenCalledWith(
-          'This is the DOM Feature App.'
+          'This is the DOM Feature App.',
         );
 
         expect(testRenderer.toJSON()).toMatchInlineSnapshot(`
@@ -1116,8 +1116,8 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
-          )
+            {testRendererOptions: {createNodeMock: () => ({})}},
+          ),
         ).not.toThrowError(mockError);
       });
 
@@ -1127,7 +1127,7 @@ describe('FeatureAppContainer', () => {
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
           />,
-          {testRendererOptions: {createNodeMock: () => ({})}}
+          {testRendererOptions: {createNodeMock: () => ({})}},
         );
 
         expect(logger.error.mock.calls).toEqual([[mockError]]);
@@ -1143,7 +1143,7 @@ describe('FeatureAppContainer', () => {
               featureAppDefinition={mockFeatureAppDefinition}
               onError={onError}
             />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
+            {testRendererOptions: {createNodeMock: () => ({})}},
           );
 
           expect(onError.mock.calls).toEqual([[mockError]]);
@@ -1166,8 +1166,8 @@ describe('FeatureAppContainer', () => {
                     throw onErrorMockError;
                   }}
                 />,
-                {testRendererOptions: {createNodeMock: () => ({})}}
-              )
+                {testRendererOptions: {createNodeMock: () => ({})}},
+              ),
             ).toThrowError(onErrorMockError);
 
             expectConsoleErrorCalls([
@@ -1182,7 +1182,7 @@ describe('FeatureAppContainer', () => {
         it('calls the function with the error', () => {
           const children = jest.fn(
             ({featureAppNode}: CustomFeatureAppRenderingParams) =>
-              featureAppNode || null
+              featureAppNode || null,
           );
 
           renderWithFeatureHubContext(
@@ -1191,7 +1191,7 @@ describe('FeatureAppContainer', () => {
               featureAppDefinition={mockFeatureAppDefinition}
               children={children}
             />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
+            {testRendererOptions: {createNodeMock: () => ({})}},
           );
 
           const expectedAfterMount: CustomFeatureAppRenderingParams = {
@@ -1207,7 +1207,7 @@ describe('FeatureAppContainer', () => {
 
           const children = jest.fn(
             ({featureAppNode}: CustomFeatureAppRenderingParams) =>
-              featureAppNode || customErrorUI
+              featureAppNode || customErrorUI,
           );
 
           const testRenderer = renderWithFeatureHubContext(
@@ -1216,7 +1216,7 @@ describe('FeatureAppContainer', () => {
               featureAppDefinition={mockFeatureAppDefinition}
               children={children}
             />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
+            {testRendererOptions: {createNodeMock: () => ({})}},
           );
 
           expect(testRenderer.toJSON()).toBe(customErrorUI);
@@ -1230,7 +1230,7 @@ describe('FeatureAppContainer', () => {
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
             />,
-            {testRendererOptions: {createNodeMock: () => ({})}}
+            {testRendererOptions: {createNodeMock: () => ({})}},
           );
 
           expect(testRenderer.toJSON()).toBeNull();
@@ -1244,7 +1244,7 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(mockFeatureAppScope.release).not.toHaveBeenCalled();
@@ -1270,7 +1270,7 @@ describe('FeatureAppContainer', () => {
             <FeatureAppContainer
               featureAppId="testId"
               featureAppDefinition={mockFeatureAppDefinition}
-            />
+            />,
           );
 
           testRenderer.unmount();
@@ -1287,7 +1287,7 @@ describe('FeatureAppContainer', () => {
                 featureAppId="testId"
                 featureAppDefinition={mockFeatureAppDefinition}
                 onError={onError}
-              />
+              />,
             );
 
             testRenderer.unmount();
@@ -1307,7 +1307,7 @@ describe('FeatureAppContainer', () => {
     {render: 'foo'},
   ]) {
     describe(`when an invalid Feature App (${JSON.stringify(
-      invalidFeatureApp
+      invalidFeatureApp,
     )}) is created`, () => {
       beforeEach(() => {
         mockFeatureAppScope = {
@@ -1321,13 +1321,13 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         expect(testRenderer.toJSON()).toBeNull();
 
         const expectedError = new Error(
-          'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.'
+          'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.',
         );
 
         expect(logger.error.mock.calls).toEqual([[expectedError]]);
@@ -1351,7 +1351,7 @@ describe('FeatureAppContainer', () => {
         <FeatureAppContainer
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
-        />
+        />,
       );
 
       expect(logger.error.mock.calls).toEqual([[mockError]]);
@@ -1366,7 +1366,7 @@ describe('FeatureAppContainer', () => {
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
             onError={onError}
-          />
+          />,
         );
 
         expect(onError.mock.calls).toEqual([[mockError]]);
@@ -1388,8 +1388,8 @@ describe('FeatureAppContainer', () => {
                 onError={() => {
                   throw onErrorMockError;
                 }}
-              />
-            )
+              />,
+            ),
           ).toThrowError(onErrorMockError);
 
           expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
@@ -1403,7 +1403,7 @@ describe('FeatureAppContainer', () => {
           <FeatureAppContainer
             featureAppId="testId"
             featureAppDefinition={mockFeatureAppDefinition}
-          />
+          />,
         );
 
         testRenderer.unmount();
@@ -1429,7 +1429,7 @@ describe('FeatureAppContainer', () => {
           featureAppId="testId"
           featureAppDefinition={mockFeatureAppDefinition}
         />,
-        {customLogger: false}
+        {customLogger: false},
       );
 
       expectConsoleErrorCalls([[mockError]]);

--- a/packages/react/src/__tests__/feature-app-loader-and-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader-and-container.test.tsx
@@ -32,8 +32,8 @@ describe('FeatureAppLoader with an unmocked InternalFeatureAppContainer', () => 
 
     mockAsyncFeatureAppDefinition = new AsyncValue(
       new Promise((resolve) =>
-        setTimeout(() => resolve(mockFeatureAppDefinition))
-      )
+        setTimeout(() => resolve(mockFeatureAppDefinition)),
+      ),
     );
 
     mockFeatureAppManager = ({
@@ -53,7 +53,7 @@ describe('FeatureAppLoader with an unmocked InternalFeatureAppContainer', () => 
 
   const renderWithFeatureHubContext = (
     node: React.ReactNode,
-    testRendererOptions?: TestRenderer.TestRendererOptions
+    testRendererOptions?: TestRenderer.TestRendererOptions,
   ) =>
     TestRenderer.create(
       <FeatureHubContextProvider
@@ -61,7 +61,7 @@ describe('FeatureAppLoader with an unmocked InternalFeatureAppContainer', () => 
       >
         {node}
       </FeatureHubContextProvider>,
-      testRendererOptions
+      testRendererOptions,
     );
 
   describe('when a Feature App definition is loaded asynchronously', () => {
@@ -72,7 +72,7 @@ describe('FeatureAppLoader with an unmocked InternalFeatureAppContainer', () => 
             <FeatureAppLoader featureAppId="testId" src="example.js">
               {({featureAppNode}) => <div>{featureAppNode}</div>}
             </FeatureAppLoader>,
-            {createNodeMock: () => ({})}
+            {createNodeMock: () => ({})},
           );
 
           await mockAsyncFeatureAppDefinition.promise;

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -33,11 +33,11 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
   beforeEach(() => {
     mockAsyncFeatureAppDefinition = new AsyncValue(
-      new Promise<FeatureAppDefinition<unknown>>(jest.fn())
+      new Promise<FeatureAppDefinition<unknown>>(jest.fn()),
     );
 
     mockGetAsyncFeatureAppDefinition = jest.fn(
-      () => mockAsyncFeatureAppDefinition
+      () => mockAsyncFeatureAppDefinition,
     );
 
     mockFeatureAppManager = ({
@@ -72,13 +72,13 @@ describe('FeatureAppLoader (on Node.js)', () => {
         }}
       >
         {node}
-      </FeatureHubContextProvider>
+      </FeatureHubContextProvider>,
     );
 
   describe('without a serverSrc', () => {
     it('does not try to load a Feature App definition', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockGetAsyncFeatureAppDefinition).not.toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
     it('does not schedule a rerender on the Async SSR Manager', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
 
     it('does not add a URL for hydration', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -124,7 +124,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
             baseUrl="http://example.com"
             src="example.js"
             serverSrc="example-node.js"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -141,12 +141,12 @@ describe('FeatureAppLoader (on Node.js)', () => {
             serverSrc="example-node.js"
             moduleType="a"
             serverModuleType="b"
-          />
+          />,
         );
 
         expect(mockAddUrlForHydration).toHaveBeenCalledWith(
           'http://example.com/example.js',
-          'a'
+          'a',
         );
       });
     });
@@ -157,7 +157,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAsyncSsrManager.scheduleRerender.mock.calls).toEqual([
@@ -171,12 +171,12 @@ describe('FeatureAppLoader (on Node.js)', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAddUrlForHydration).toHaveBeenCalledWith(
         'example.js',
-        undefined
+        undefined,
       );
     });
 
@@ -189,7 +189,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
             serverSrc="example-node.js"
             moduleType="a"
             serverModuleType="b"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -205,7 +205,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
         mockFeatureAppDefinition = {create: jest.fn()};
 
         mockAsyncFeatureAppDefinition = new AsyncValue(
-          Promise.resolve(mockFeatureAppDefinition)
+          Promise.resolve(mockFeatureAppDefinition),
         );
       });
 
@@ -215,7 +215,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
             featureAppId="testId"
             src="example.js"
             serverSrc="example-node.js"
-          />
+          />,
         );
 
         expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -236,7 +236,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
             src="example.js"
             serverSrc="example-node.js"
             featureAppId="testId"
-          />
+          />,
         );
 
         expect(consoleErrorSpy.mock.calls).toEqual([
@@ -254,7 +254,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
               featureAppId="testId"
               src="example.js"
               serverSrc="example-node.js"
-            />
+            />,
           );
         } catch {}
 
@@ -268,13 +268,13 @@ describe('FeatureAppLoader (on Node.js)', () => {
               featureAppId="testId"
               src="example.js"
               serverSrc="example-node.js"
-            />
+            />,
           );
         } catch {}
 
         expect(mockAddUrlForHydration).toHaveBeenCalledWith(
           'example.js',
-          undefined
+          undefined,
         );
       });
     });
@@ -287,7 +287,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
@@ -302,7 +302,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           src="example.js"
           serverSrc="example-node.js"
           css={[{href: 'foo.css'}]}
-        />
+        />,
       );
 
       expect(mockAddStylesheetsForSsr.mock.calls).toEqual([
@@ -322,7 +322,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
               {href: 'http://example.com/foo.css'},
               {href: 'bar.css', media: 'print'},
             ]}
-          />
+          />,
         );
 
         expect(mockAddStylesheetsForSsr.mock.calls).toEqual([

--- a/packages/react/src/__tests__/feature-app-loader.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.test.tsx
@@ -24,7 +24,7 @@ interface MockAsyncSsrManager extends AsyncSsrManagerV1 {
 
 jest.mock('../internal/internal-feature-app-container', () => ({
   InternalFeatureAppContainer: jest.fn(
-    () => 'mocked InternalFeatureAppContainer'
+    () => 'mocked InternalFeatureAppContainer',
   ),
 }));
 
@@ -40,7 +40,7 @@ describe('FeatureAppLoader', () => {
   const usingTestErrorBoundaryConsoleErrorCalls = [
     [
       expect.stringContaining(
-        'React will try to recreate this component tree from scratch using the error boundary you provided, TestErrorBoundary.'
+        'React will try to recreate this component tree from scratch using the error boundary you provided, TestErrorBoundary.',
       ),
     ],
   ];
@@ -48,7 +48,7 @@ describe('FeatureAppLoader', () => {
   const noErrorBoundaryConsoleErrorCalls = [
     [
       expect.stringContaining(
-        'Consider adding an error boundary to your tree to customize error handling behavior.'
+        'Consider adding an error boundary to your tree to customize error handling behavior.',
       ),
     ],
   ];
@@ -77,11 +77,11 @@ describe('FeatureAppLoader', () => {
     }
 
     mockAsyncFeatureAppDefinition = new AsyncValue(
-      new Promise<FeatureAppDefinition<unknown>>(jest.fn())
+      new Promise<FeatureAppDefinition<unknown>>(jest.fn()),
     );
 
     mockGetAsyncFeatureAppDefinition = jest.fn(
-      () => mockAsyncFeatureAppDefinition
+      () => mockAsyncFeatureAppDefinition,
     );
 
     mockFeatureAppManager = ({
@@ -107,12 +107,12 @@ describe('FeatureAppLoader', () => {
   it('throws an error when rendered without a FeatureHubContextProvider', () => {
     expect(() =>
       TestRenderer.create(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
-      )
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
+      ),
     ).toThrowError(
       new Error(
-        'No Feature Hub context was provided! There are two possible causes: 1.) No FeatureHubContextProvider was rendered in the React tree. 2.) A Feature App that renders itself a FeatureAppLoader or a FeatureAppContainer did not declare @feature-hub/react as an external package.'
-      )
+        'No Feature Hub context was provided! There are two possible causes: 1.) No FeatureHubContextProvider was rendered in the React tree. 2.) A Feature App that renders itself a FeatureAppLoader or a FeatureAppContainer did not declare @feature-hub/react as an external package.',
+      ),
     );
 
     expectConsoleErrorCalls(noErrorBoundaryConsoleErrorCalls);
@@ -120,7 +120,10 @@ describe('FeatureAppLoader', () => {
 
   const renderWithFeatureHubContext = (
     node: React.ReactNode,
-    options: {customLogger?: boolean; handleError?: (error: Error) => void} = {}
+    options: {
+      customLogger?: boolean;
+      handleError?: (error: Error) => void;
+    } = {},
   ) => {
     const {customLogger = true, handleError = jest.fn()} = options;
 
@@ -135,7 +138,7 @@ describe('FeatureAppLoader', () => {
         }}
       >
         <TestErrorBoundary handleError={handleError}>{node}</TestErrorBoundary>
-      </FeatureHubContextProvider>
+      </FeatureHubContextProvider>,
     );
   };
 
@@ -144,7 +147,7 @@ describe('FeatureAppLoader', () => {
 
     const testRenderer = renderWithFeatureHubContext(
       <FeatureAppLoader featureAppId="testId" src="" />,
-      {handleError}
+      {handleError},
     );
 
     expect(handleError.mock.calls).toEqual([[new Error('No src provided.')]]);
@@ -156,7 +159,7 @@ describe('FeatureAppLoader', () => {
     describe('when given no children function', () => {
       it('renders nothing', () => {
         const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader featureAppId="testId" src="example.js" />
+          <FeatureAppLoader featureAppId="testId" src="example.js" />,
         );
 
         expect(testRenderer.toJSON()).toBeNull();
@@ -167,7 +170,7 @@ describe('FeatureAppLoader', () => {
   describe('without a css prop', () => {
     it('does not change the document head', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(document.head).toMatchSnapshot();
@@ -175,7 +178,7 @@ describe('FeatureAppLoader', () => {
 
     it('does not try to add stylesheets for SSR', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
@@ -192,7 +195,7 @@ describe('FeatureAppLoader', () => {
             {href: 'https://example.com/foo.css'},
             {href: 'bar.css', media: 'print'},
           ]}
-        />
+        />,
       );
 
       expect(document.head).toMatchSnapshot();
@@ -204,7 +207,7 @@ describe('FeatureAppLoader', () => {
           featureAppId="testId"
           src="example.js"
           css={[{href: 'foo.css'}]}
-        />
+        />,
       );
 
       expect(mockAddStylesheetsForSsr).not.toHaveBeenCalled();
@@ -217,7 +220,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             css={[{href: 'foo.css'}]}
-          />
+          />,
         );
 
         renderWithFeatureHubContext(
@@ -225,7 +228,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             css={[{href: 'foo.css'}]}
-          />
+          />,
         );
 
         expect(document.head).toMatchSnapshot();
@@ -243,7 +246,7 @@ describe('FeatureAppLoader', () => {
               {href: 'https://example.com/foo.css'},
               {href: 'bar.css', media: 'print'},
             ]}
-          />
+          />,
         );
 
         expect(document.head).toMatchSnapshot();
@@ -258,13 +261,13 @@ describe('FeatureAppLoader', () => {
       mockFeatureAppDefinition = {create: jest.fn()};
 
       mockAsyncFeatureAppDefinition = new AsyncValue(
-        Promise.resolve(mockFeatureAppDefinition)
+        Promise.resolve(mockFeatureAppDefinition),
       );
     });
 
     it('calls getAsyncFeatureAppDefinition with the given src exactly once', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -279,7 +282,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             baseUrl="/base"
             src="example.js"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -295,7 +298,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             baseUrl="/base"
             src="http://example.com/foo.js"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -312,7 +315,7 @@ describe('FeatureAppLoader', () => {
             src="example.js"
             moduleType="a"
             serverModuleType="b"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -337,7 +340,7 @@ describe('FeatureAppLoader', () => {
           onError={onError}
           baseUrl="/base"
           children={children}
-        />
+        />,
       );
 
       expect(testRenderer.toJSON()).toBe('mocked InternalFeatureAppContainer');
@@ -357,7 +360,7 @@ describe('FeatureAppLoader', () => {
 
       expect(InternalFeatureAppContainer).toHaveBeenCalledWith(
         expectedProps,
-        {}
+        {},
       );
     });
 
@@ -367,7 +370,7 @@ describe('FeatureAppLoader', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -379,7 +382,7 @@ describe('FeatureAppLoader', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
@@ -395,13 +398,13 @@ describe('FeatureAppLoader', () => {
       mockAsyncFeatureAppDefinition = new AsyncValue(
         Promise.reject(mockError),
         undefined,
-        mockError
+        mockError,
       );
     });
 
     it('renders nothing and logs an error (only once)', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" featureAppId="testId" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />,
       );
 
       try {
@@ -429,7 +432,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             onError={onError}
-          />
+          />,
         );
 
         expect(onError.mock.calls).toEqual([[mockError]]);
@@ -441,7 +444,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             onError={jest.fn()}
-          />
+          />,
         );
 
         expect(logger.error).not.toHaveBeenCalled();
@@ -465,7 +468,7 @@ describe('FeatureAppLoader', () => {
                 throw onErrorMockError;
               }}
             />,
-            {handleError}
+            {handleError},
           );
 
           expect(handleError.mock.calls).toEqual([[onErrorMockError]]);
@@ -484,7 +487,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             children={children}
-          />
+          />,
         );
 
         const expectedParameter: CustomFeatureAppRenderingParams = {
@@ -504,7 +507,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             src="example.js"
             children={children}
-          />
+          />,
         );
 
         expect(testRenderer.toJSON()).toBe('Custom Error UI');
@@ -528,7 +531,7 @@ describe('FeatureAppLoader', () => {
                 throw childrenMockError;
               }}
             />,
-            {handleError}
+            {handleError},
           );
 
           expect(handleError.mock.calls).toEqual([[childrenMockError]]);
@@ -547,7 +550,7 @@ describe('FeatureAppLoader', () => {
               src="example.js"
               onError={onError}
               children={jest.fn().mockReturnValue(null)}
-            />
+            />,
           );
 
           expect(onError.mock.calls).toEqual([[mockError]]);
@@ -573,7 +576,7 @@ describe('FeatureAppLoader', () => {
                 }}
                 children={children}
               />,
-              {handleError}
+              {handleError},
             );
 
             expect(children).not.toHaveBeenCalled();
@@ -595,14 +598,14 @@ describe('FeatureAppLoader', () => {
       mockAsyncFeatureAppDefinition = new AsyncValue(
         new Promise<FeatureAppDefinition<unknown>>((resolve) =>
           // defer to next event loop turn to guarantee asynchronism
-          setTimeout(() => resolve(mockFeatureAppDefinition))
-        )
+          setTimeout(() => resolve(mockFeatureAppDefinition)),
+        ),
       );
     });
 
     it('calls getAsyncFeatureAppDefinition with the given src exactly twice', () => {
       renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -618,7 +621,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             baseUrl="/base"
             src="example.js"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -635,7 +638,7 @@ describe('FeatureAppLoader', () => {
             featureAppId="testId"
             baseUrl="/base"
             src="http://example.com/foo.js"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -653,7 +656,7 @@ describe('FeatureAppLoader', () => {
             src="example.js"
             moduleType="a"
             serverModuleType="b"
-          />
+          />,
         );
 
         expect(mockGetAsyncFeatureAppDefinition.mock.calls).toEqual([
@@ -665,7 +668,7 @@ describe('FeatureAppLoader', () => {
 
     it('initially renders nothing', () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader featureAppId="testId" src="example.js" />
+        <FeatureAppLoader featureAppId="testId" src="example.js" />,
       );
 
       expect(testRenderer.toJSON()).toBeNull();
@@ -673,7 +676,7 @@ describe('FeatureAppLoader', () => {
 
     it('renders a FeatureAppContainer when loaded', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" featureAppId="testId" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />,
       );
 
       await mockAsyncFeatureAppDefinition.promise;
@@ -687,7 +690,7 @@ describe('FeatureAppLoader', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
@@ -699,7 +702,7 @@ describe('FeatureAppLoader', () => {
           featureAppId="testId"
           src="example.js"
           serverSrc="example-node.js"
-        />
+        />,
       );
 
       expect(mockAddUrlForHydration).not.toHaveBeenCalled();
@@ -708,7 +711,7 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('renders nothing', async () => {
         const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader featureAppId="testId" src="example.js" />
+          <FeatureAppLoader featureAppId="testId" src="example.js" />,
         );
 
         testRenderer.unmount();
@@ -729,14 +732,14 @@ describe('FeatureAppLoader', () => {
       mockAsyncFeatureAppDefinition = new AsyncValue(
         new Promise<FeatureAppDefinition<unknown>>((_, reject) =>
           // defer to next event loop turn to guarantee asynchronism
-          setTimeout(() => reject(mockError))
-        )
+          setTimeout(() => reject(mockError)),
+        ),
       );
     });
 
     it('renders nothing and logs an error', async () => {
       const testRenderer = renderWithFeatureHubContext(
-        <FeatureAppLoader src="example.js" featureAppId="testId" />
+        <FeatureAppLoader src="example.js" featureAppId="testId" />,
       );
 
       expect.assertions(4); // Note: one of the assertions is in afterEach.
@@ -767,7 +770,7 @@ describe('FeatureAppLoader', () => {
               featureAppId="testId"
               src="example.js"
               onError={onError}
-            />
+            />,
           );
 
           await mockAsyncFeatureAppDefinition.promise;
@@ -783,7 +786,7 @@ describe('FeatureAppLoader', () => {
               featureAppId="testId"
               src="example.js"
               onError={jest.fn()}
-            />
+            />,
           );
 
           await mockAsyncFeatureAppDefinition.promise;
@@ -810,7 +813,7 @@ describe('FeatureAppLoader', () => {
                 throw onErrorMockError;
               }}
             />,
-            {handleError}
+            {handleError},
           );
 
           try {
@@ -833,7 +836,7 @@ describe('FeatureAppLoader', () => {
                 featureAppId="testId"
                 src="example.js"
                 onError={onError}
-              />
+              />,
             );
 
             testRenderer.unmount();
@@ -853,7 +856,7 @@ describe('FeatureAppLoader', () => {
                 onError={() => {
                   throw onErrorMockError;
                 }}
-              />
+              />,
             );
 
             testRenderer.unmount();
@@ -871,7 +874,7 @@ describe('FeatureAppLoader', () => {
     describe('when unmounted before loading has finished', () => {
       it('logs an error', async () => {
         const testRenderer = renderWithFeatureHubContext(
-          <FeatureAppLoader featureAppId="testId" src="example.js" />
+          <FeatureAppLoader featureAppId="testId" src="example.js" />,
         );
 
         testRenderer.unmount();
@@ -901,12 +904,12 @@ describe('FeatureAppLoader', () => {
       mockAsyncFeatureAppDefinition = new AsyncValue(
         Promise.reject(mockError),
         undefined,
-        mockError
+        mockError,
       );
 
       renderWithFeatureHubContext(
         <FeatureAppLoader src="example.js" featureAppId="testId" />,
-        {customLogger: false}
+        {customLogger: false},
       );
 
       expectConsoleErrorCalls([

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -116,7 +116,7 @@ export function FeatureAppContainer<
   TFeatureServices extends FeatureServices = FeatureServices,
   TConfig = unknown
 >(
-  props: FeatureAppContainerProps<TFeatureApp, TFeatureServices, TConfig>
+  props: FeatureAppContainerProps<TFeatureApp, TFeatureServices, TConfig>,
 ): JSX.Element {
   return (
     <FeatureHubContextConsumer>

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -68,7 +68,7 @@ export interface FeatureAppLoaderProps<TConfig = unknown>
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    env: FeatureAppEnvironment<FeatureServices, TConfig>
+    env: FeatureAppEnvironment<FeatureServices, TConfig>,
   ) => void;
 
   /**
@@ -90,7 +90,7 @@ export interface FeatureAppLoaderProps<TConfig = unknown>
    * Feature App and provide Error or Loading UIs.
    */
   readonly children?: (
-    params: CustomFeatureAppRenderingParams
+    params: CustomFeatureAppRenderingParams,
   ) => React.ReactNode;
 }
 
@@ -188,7 +188,7 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
     try {
       const featureAppDefinition = await featureAppManager.getAsyncFeatureAppDefinition(
         prependBaseUrl(baseUrl, src),
-        moduleType
+        moduleType,
       ).promise;
 
       if (this.mounted) {
@@ -278,7 +278,7 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
             rel: 'stylesheet',
             href,
             media,
-          })
+          }),
         );
       }
     }
@@ -324,9 +324,9 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
 
     logger.error(
       `The Feature App for the src ${JSON.stringify(
-        src && prependBaseUrl(baseUrl, src)
+        src && prependBaseUrl(baseUrl, src),
       )} and the ID ${JSON.stringify(featureAppId)} could not be rendered.`,
-      error
+      error,
     );
   }
 }
@@ -342,7 +342,7 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
  * errors are not caught and must therefore be handled by the integrator.
  */
 export function FeatureAppLoader<TConfig>(
-  props: FeatureAppLoaderProps<TConfig>
+  props: FeatureAppLoaderProps<TConfig>,
 ): JSX.Element {
   return (
     <FeatureHubContextConsumer>

--- a/packages/react/src/feature-hub-context.tsx
+++ b/packages/react/src/feature-hub-context.tsx
@@ -84,7 +84,7 @@ export const FeatureHubContextProvider = FeatureHubContext.Provider;
  * [[FeatureAppLoader]] and [[FeatureAppContainer]].
  */
 export function FeatureHubContextConsumer(
-  props: React.ConsumerProps<FeatureHubContextConsumerValue>
+  props: React.ConsumerProps<FeatureHubContextConsumerValue>,
 ): JSX.Element {
   return (
     <FeatureHubContext.Consumer>

--- a/packages/react/src/internal/internal-feature-app-container.tsx
+++ b/packages/react/src/internal/internal-feature-app-container.tsx
@@ -16,7 +16,7 @@ import {isDomFeatureApp, isFeatureApp, isReactFeatureApp} from './type-guards';
 export const handleError = (
   logger: Logger,
   error: unknown,
-  onError?: (e: unknown) => void
+  onError?: (e: unknown) => void,
 ) => {
   if (onError) {
     onError(error);
@@ -71,7 +71,7 @@ export interface BaseFeatureAppContainerProps<
    * A callback that is called before the Feature App is created.
    */
   readonly beforeCreate?: (
-    env: FeatureAppEnvironment<TFeatureServices, TConfig>
+    env: FeatureAppEnvironment<TFeatureServices, TConfig>,
   ) => void;
 
   /**
@@ -93,7 +93,7 @@ export interface BaseFeatureAppContainerProps<
    * Feature App and provide Error or Loading UIs.
    */
   readonly children?: (
-    params: CustomFeatureAppRenderingParams
+    params: CustomFeatureAppRenderingParams,
   ) => React.ReactNode;
 }
 
@@ -127,7 +127,7 @@ export class InternalFeatureAppContainer<
 > {
   public static getDerivedStateFromProps(
     props: InternalFeatureAppContainerProps<unknown, FeatureServices, unknown>,
-    state: InternalFeatureAppContainerState<FeatureApp>
+    state: InternalFeatureAppContainerState<FeatureApp>,
   ): Partial<InternalFeatureAppContainerState<FeatureApp>> | null {
     const {
       baseUrl,
@@ -155,14 +155,14 @@ export class InternalFeatureAppContainer<
             beforeCreate,
             done,
             parentFeatureApp,
-          }
+          },
         );
 
         const {featureApp, release} = featureAppScope;
 
         if (!isFeatureApp(featureApp)) {
           throw new Error(
-            'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.'
+            'Invalid Feature App found. The Feature App must be an object with either 1) a `render` method that returns a React element, or 2) an `attachTo` method that accepts a container DOM element.',
           );
         }
 

--- a/packages/react/src/internal/type-guards.ts
+++ b/packages/react/src/internal/type-guards.ts
@@ -5,13 +5,13 @@ import {
 } from '../feature-app-container';
 
 export function isDomFeatureApp(
-  featureApp: object
+  featureApp: object,
 ): featureApp is DomFeatureApp {
   return typeof (featureApp as DomFeatureApp).attachTo === 'function';
 }
 
 export function isReactFeatureApp(
-  featureApp: object
+  featureApp: object,
 ): featureApp is ReactFeatureApp {
   return typeof (featureApp as ReactFeatureApp).render === 'function';
 }

--- a/packages/serialized-state-manager/src/__tests__/index.test.ts
+++ b/packages/serialized-state-manager/src/__tests__/index.test.ts
@@ -16,7 +16,7 @@ describe('defineSerializedStateManager', () => {
 
   it('defines an id', () => {
     expect(serializedStateManagerDefinition.id).toBe(
-      's2:serialized-state-manager'
+      's2:serialized-state-manager',
     );
   });
 
@@ -24,14 +24,14 @@ describe('defineSerializedStateManager', () => {
     expect(serializedStateManagerDefinition.dependencies).toBeUndefined();
 
     expect(
-      serializedStateManagerDefinition.optionalDependencies
+      serializedStateManagerDefinition.optionalDependencies,
     ).toBeUndefined();
   });
 
   describe('#create', () => {
     it('creates a shared Feature Service containing version 1.0.0', () => {
       const sharedSerializedStateManager = serializedStateManagerDefinition.create(
-        mockEnv
+        mockEnv,
       );
 
       expect(sharedSerializedStateManager!['1.0.0']).toBeDefined();
@@ -45,19 +45,19 @@ describe('defineSerializedStateManager', () => {
 
     beforeEach(() => {
       const serializedStateManagerBinder = serializedStateManagerDefinition.create(
-        mockEnv
+        mockEnv,
       )!['1.0.0'];
 
       integratorSerializedStateManager = serializedStateManagerBinder(
-        'test:integrator'
+        'test:integrator',
       ).featureService;
 
       consumer1SerializedStateManager = serializedStateManagerBinder(
-        'test:consumer:1'
+        'test:consumer:1',
       ).featureService;
 
       consumer2SerializedStateManager = serializedStateManagerBinder(
-        'test:consumer:2'
+        'test:consumer:2',
       ).featureService;
     });
 
@@ -65,7 +65,7 @@ describe('defineSerializedStateManager', () => {
       describe('when no consumer has called #register', () => {
         it('returns a stringified empty object', () => {
           expect(integratorSerializedStateManager.serializeStates()).toBe(
-            encodeURI(JSON.stringify({}))
+            encodeURI(JSON.stringify({})),
           );
         });
       });
@@ -73,11 +73,11 @@ describe('defineSerializedStateManager', () => {
       describe('when consumers have called #register', () => {
         beforeEach(() => {
           consumer1SerializedStateManager.register(() =>
-            JSON.stringify({kind: 'foo'})
+            JSON.stringify({kind: 'foo'}),
           );
 
           consumer2SerializedStateManager.register(() =>
-            JSON.stringify({kind: 'bar'})
+            JSON.stringify({kind: 'bar'}),
           );
         });
 
@@ -87,8 +87,8 @@ describe('defineSerializedStateManager', () => {
               JSON.stringify({
                 'test:consumer:1': JSON.stringify({kind: 'foo'}),
                 'test:consumer:2': JSON.stringify({kind: 'bar'}),
-              })
-            )
+              }),
+            ),
           );
         });
       });
@@ -98,11 +98,11 @@ describe('defineSerializedStateManager', () => {
       describe('when the integrator has not called #setSerializedStates', () => {
         it('returns undefined', () => {
           expect(
-            consumer1SerializedStateManager.getSerializedState()
+            consumer1SerializedStateManager.getSerializedState(),
           ).toBeUndefined();
 
           expect(
-            consumer2SerializedStateManager.getSerializedState()
+            consumer2SerializedStateManager.getSerializedState(),
           ).toBeUndefined();
         });
       });
@@ -113,20 +113,20 @@ describe('defineSerializedStateManager', () => {
             encodeURI(
               JSON.stringify({
                 'test:consumer:1': JSON.stringify({kind: 'foo'}),
-              })
-            )
+              }),
+            ),
           );
         });
 
         it('returns the serialized state for the first consumer', () => {
           expect(consumer1SerializedStateManager.getSerializedState()).toBe(
-            JSON.stringify({kind: 'foo'})
+            JSON.stringify({kind: 'foo'}),
           );
         });
 
         it('returns undefined for the second consumer', () => {
           expect(
-            consumer2SerializedStateManager.getSerializedState()
+            consumer2SerializedStateManager.getSerializedState(),
           ).toBeUndefined();
         });
       });
@@ -136,27 +136,27 @@ describe('defineSerializedStateManager', () => {
 
         beforeEach(() => {
           const serializedStateManagerBinder = defineSerializedStateManager(
-            JSON.stringify({'test:consumer:1': serializedStateConsumer1})
+            JSON.stringify({'test:consumer:1': serializedStateConsumer1}),
           ).create(mockEnv)!['1.0.0'];
 
           consumer1SerializedStateManager = serializedStateManagerBinder(
-            'test:consumer:1'
+            'test:consumer:1',
           ).featureService;
 
           consumer2SerializedStateManager = serializedStateManagerBinder(
-            'test:consumer:2'
+            'test:consumer:2',
           ).featureService;
         });
 
         it('returns the serialized state for the first consumer', () => {
           expect(consumer1SerializedStateManager.getSerializedState()).toBe(
-            serializedStateConsumer1
+            serializedStateConsumer1,
           );
         });
 
         it('returns undefined for the second consumer', () => {
           expect(
-            consumer2SerializedStateManager.getSerializedState()
+            consumer2SerializedStateManager.getSerializedState(),
           ).toBeUndefined();
         });
       });

--- a/packages/serialized-state-manager/src/index.ts
+++ b/packages/serialized-state-manager/src/index.ts
@@ -57,7 +57,7 @@ export interface SharedSerializedStateManager extends SharedFeatureService {
  * [[SerializedStateManagerV1.setSerializedStates]] after its creation.
  */
 export function defineSerializedStateManager(
-  serializedStates?: string
+  serializedStates?: string,
 ): FeatureServiceProviderDefinition<SharedSerializedStateManager> {
   return {
     id: 's2:serialized-state-manager',
@@ -75,7 +75,7 @@ export function defineSerializedStateManager(
           featureService: new SerializedStateManager(
             consumerId,
             serverSideStateManager,
-            clientSideStateManager
+            clientSideStateManager,
           ),
         }),
       };

--- a/packages/serialized-state-manager/src/internal/serialized-state-manager.ts
+++ b/packages/serialized-state-manager/src/internal/serialized-state-manager.ts
@@ -6,7 +6,7 @@ export class SerializedStateManager implements SerializedStateManagerV1 {
   public constructor(
     private readonly consumerId: string,
     private readonly serverSideStateManager: ServerSideStateManager,
-    private readonly clientSideStateManager: ClientSideStateManager
+    private readonly clientSideStateManager: ClientSideStateManager,
   ) {}
 
   public register(serializeState: () => string): void {

--- a/packages/serialized-state-manager/src/internal/server-side-state-manager.ts
+++ b/packages/serialized-state-manager/src/internal/server-side-state-manager.ts
@@ -11,7 +11,7 @@ export class ServerSideStateManager {
     this.serializeStateCallbacks.forEach(
       (serializeState, currentConsumerId) => {
         serializedStatesByConsumerId[currentConsumerId] = serializeState();
-      }
+      },
     );
 
     return encodeURI(JSON.stringify(serializedStatesByConsumerId));

--- a/packages/server-request/src/index.ts
+++ b/packages/server-request/src/index.ts
@@ -15,7 +15,7 @@ export interface SharedServerRequest extends SharedFeatureService {
 }
 
 export function defineServerRequest(
-  serverRequest: ServerRequestV1
+  serverRequest: ServerRequestV1,
 ): FeatureServiceProviderDefinition<SharedServerRequest> {
   return {
     id: 's2:server-request',

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,4 +4,5 @@ module.exports = {
   bracketSpacing: false,
   proseWrap: 'always',
   singleQuote: true,
+  trailingComma: 'all',
 };

--- a/scripts/process-api-docs.js
+++ b/scripts/process-api-docs.js
@@ -6,7 +6,7 @@ const updateHtmlFile = require('./update-html-file');
 
 const apiDocsDirname = path.join(
   __dirname,
-  '../packages/website/build/feature-hub/api'
+  '../packages/website/build/feature-hub/api',
 );
 
 // Rename "Modules" to "Packages" on the index page.


### PR DESCRIPTION
This is in preparation for the update to v3, where this is becoming the default, so that we can separate the comma changes from the rest.