### PR TITLE
ci(all): turns out, in the CI we do need more memory for the itests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: yarn test:unit --no-cache --maxWorkers 2 --no-verbose
 
       - name: Integration Tests
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: yarn test:integration --no-cache --maxWorkers 2
 
   compile-lint-verify:


### PR DESCRIPTION
e.g.: https://github.com/sinnerschrader/feature-hub/actions/runs/6349645512/job/17248138106