### PR TITLE
feat(module-loader-amd): update SystemJS

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -24,7 +24,7 @@ module.exports = [
   },
   {
     path: 'packages/module-loader-amd/lib/esm/index.js',
-    limit: '8 KB',
+    limit: '4.2 KB',
   },
   {
     path: 'packages/module-loader-federation/lib/esm/index.js',

--- a/packages/module-loader-amd/package.json
+++ b/packages/module-loader-amd/package.json
@@ -21,10 +21,10 @@
   "module": "lib/esm/index.js",
   "typings": "lib/cjs/index.d.ts",
   "dependencies": {
-    "systemjs": "^0.21.5"
+    "systemjs": "^6.14.2"
   },
   "devDependencies": {
-    "@types/systemjs": "^0.20.6"
+    "@types/systemjs": "^6.13.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/module-loader-amd/src/index.ts
+++ b/packages/module-loader-amd/src/index.ts
@@ -1,4 +1,8 @@
-import 'systemjs/dist/system-production';
+// tslint:disable:ordered-imports
+import 'systemjs/dist/s.js';
+import 'systemjs/dist/extras/named-register.js';
+import 'systemjs/dist/extras/amd.js';
+// tslint:enable:ordered-imports
 
 export interface Externals {
   readonly [externalName: string]: unknown;
@@ -11,9 +15,11 @@ export interface Externals {
  */
 export function defineExternals(externals: Externals): void {
   for (const externalName of Object.keys(externals)) {
-    const external = externals[externalName];
+    System.register(externalName, [], (exportFn) => {
+      exportFn(externals[externalName] as System.Module);
 
-    SystemJS.amdDefine(externalName, () => external);
+      return {};
+    });
   }
 }
 
@@ -24,5 +30,13 @@ export function defineExternals(externals: Externals): void {
  * the module can not be loaded.
  */
 export async function loadAmdModule(url: string): Promise<unknown> {
-  return SystemJS.import(url);
+  return (await System.import(normalizeUrlForSystemJs(url))).default;
+}
+
+function normalizeUrlForSystemJs(url: string): string {
+  if (/^https?:\/\//.test(url) || /^\.?\//.test(url)) {
+    return url;
+  }
+
+  return `./${url}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4827,10 +4827,10 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
-"@types/systemjs@^0.20.6":
-  version "0.20.6"
-  resolved "https://registry.yarnpkg.com/@types/systemjs/-/systemjs-0.20.6.tgz#79838d2b4bce9c014330efa0b4c7b9345e830a72"
-  integrity sha512-p3yv9sBBJXi3noUG216BpUI7VtVBUAvBIfZNTiDROUY31YBfsFHM4DreS7XMekN8IjtX0ysvCnm6r3WnirnNeA==
+"@types/systemjs@^6.13.3":
+  version "6.13.3"
+  resolved "https://registry.yarnpkg.com/@types/systemjs/-/systemjs-6.13.3.tgz#ac0d444fd30ef4dd0a1e5b66eb48924992dafb22"
+  integrity sha512-y+YbooRJv77KiKo9uoivF5Vwu9DcQQw0GmqocqozISnuYTFI7JKlfP0XquXwVmRE0JcxIoYVtfYTYEnq2vvVxg==
 
 "@types/toposort@^2.0.1":
   version "2.0.1"
@@ -16138,10 +16138,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-systemjs@^0.21.5:
-  version "0.21.6"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-0.21.6.tgz#9d15e79d9f60abbac23f0d179f887ec01f260a1b"
-  integrity sha512-R+5S9eV9vcQgWOoS4D87joZ4xkFJHb19ZsyKY07D1+VBDE9bwYcU+KXE0r5XlDA8mFoJGyuWDbfrNoh90JsA8g==
+systemjs@^6.14.2:
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.14.2.tgz#e289f959f8c8b407403bd39c6abaa16f2c13f316"
+  integrity sha512-1TlOwvKWdXxAY9vba+huLu99zrQURDWA8pUTYsRIYDZYQbGyK+pyEP4h4dlySsqo7ozyJBmYD20F+iUHhAltEg==
 
 tapable@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
fixes #80

Note that the breaking change mentioned in #80 is no longer required (see also https://github.com/systemjs/systemjs#compatibility-with-webpack).