### PR TITLE
feat(core): include consumer ID in externals validation

### DIFF
--- a/packages/core/src/__tests__/create-feature-hub.test.ts
+++ b/packages/core/src/__tests__/create-feature-hub.test.ts
@@ -131,7 +131,9 @@ describe('createFeatureHub()', () => {
             mockFeatureAppDefinition,
           ),
         ).toThrowError(
-          new Error('The external dependency "foo" is not provided.'),
+          new Error(
+            'The external dependency "foo" as required by "test:feature-app" is not provided.',
+          ),
         );
       });
     });
@@ -217,7 +219,9 @@ describe('createFeatureHub()', () => {
         expect(() =>
           createFeatureHub('test:integrator', featureHubOptions),
         ).toThrowError(
-          new Error('The external dependency "foo" is not provided.'),
+          new Error(
+            'The external dependency "foo" as required by "test:feature-service" is not provided.',
+          ),
         );
       });
     });

--- a/packages/core/src/__tests__/externals-validator.test.ts
+++ b/packages/core/src/__tests__/externals-validator.test.ts
@@ -38,6 +38,14 @@ describe('ExternalsValidator', () => {
           'The external dependency "react" in the required version range "^16.7.0" is not satisfied. The provided version is "16.6.0".',
         ),
       );
+
+      expect(() => {
+        validator.validate({react: '^16.7.0'}, 'test-consumer');
+      }).toThrowError(
+        new Error(
+          'The external dependency "react" as required by "test-consumer" in the version range "^16.7.0" is not satisfied. The provided version is "16.6.0".',
+        ),
+      );
     });
 
     it('throws an error for an unsatisfied required external (not provided)', () => {
@@ -47,6 +55,14 @@ describe('ExternalsValidator', () => {
         validator.validate({react: '^16.7.0'});
       }).toThrowError(
         new Error('The external dependency "react" is not provided.'),
+      );
+
+      expect(() => {
+        validator.validate({react: '^16.7.0'}, 'test-consumer');
+      }).toThrowError(
+        new Error(
+          'The external dependency "react" as required by "test-consumer" is not provided.',
+        ),
       );
     });
 
@@ -58,6 +74,14 @@ describe('ExternalsValidator', () => {
       }).toThrowError(
         new Error(
           'The external dependency "react" in the required version range "invalid" is not satisfied. The provided version is "16.6.0".',
+        ),
+      );
+
+      expect(() => {
+        validator.validate({react: 'invalid'}, 'test-consumer');
+      }).toThrowError(
+        new Error(
+          'The external dependency "react" as required by "test-consumer" in the version range "invalid" is not satisfied. The provided version is "16.6.0".',
         ),
       );
     });

--- a/packages/core/src/__tests__/feature-app-manager.test.ts
+++ b/packages/core/src/__tests__/feature-app-manager.test.ts
@@ -480,9 +480,10 @@ describe('FeatureAppManager', () => {
             );
           } catch {}
 
-          expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
-            react: '^16.0.0',
-          });
+          expect(mockExternalsValidator.validate).toHaveBeenCalledWith(
+            {react: '^16.0.0'},
+            'testId',
+          );
         });
 
         it('throws the validation error', () => {
@@ -513,9 +514,10 @@ describe('FeatureAppManager', () => {
             mockFeatureAppDefinition,
           );
 
-          expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
-            react: '^16.0.0',
-          });
+          expect(mockExternalsValidator.validate).toHaveBeenCalledWith(
+            {react: '^16.0.0'},
+            'testId',
+          );
         });
 
         it("doesn't throw an error", () => {

--- a/packages/core/src/__tests__/feature-service-registry.test.ts
+++ b/packages/core/src/__tests__/feature-service-registry.test.ts
@@ -415,9 +415,10 @@ describe('FeatureServiceRegistry', () => {
             );
           } catch {}
 
-          expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
-            react: '^16.0.0',
-          });
+          expect(mockExternalsValidator.validate).toHaveBeenCalledWith(
+            {react: '^16.0.0'},
+            'a',
+          );
         });
 
         it('throws the validation error', () => {
@@ -450,9 +451,10 @@ describe('FeatureServiceRegistry', () => {
             );
           } catch {}
 
-          expect(mockExternalsValidator.validate).toHaveBeenCalledWith({
-            react: '^16.0.0',
-          });
+          expect(mockExternalsValidator.validate).toHaveBeenCalledWith(
+            {react: '^16.0.0'},
+            'a',
+          );
         });
 
         it("doesn't throw an error", () => {

--- a/packages/core/src/externals-validator.ts
+++ b/packages/core/src/externals-validator.ts
@@ -44,7 +44,10 @@ export class ExternalsValidator {
    *
    * @throws Throws an error if the required externals can't be satisfied.
    */
-  public validate(requiredExternals: RequiredExternals): void {
+  public validate(
+    requiredExternals: RequiredExternals,
+    consumerId?: string,
+  ): void {
     for (const [externalName, versionRange] of Object.entries(
       requiredExternals,
     )) {
@@ -52,17 +55,19 @@ export class ExternalsValidator {
 
       if (!providedVersion) {
         throw new Error(
-          `The external dependency ${JSON.stringify(
-            externalName,
-          )} is not provided.`,
+          `The external dependency ${JSON.stringify(externalName)}${
+            consumerId ? ` as required by ${JSON.stringify(consumerId)}` : ``
+          } is not provided.`,
         );
       }
 
       if (!semverSatisfies(providedVersion, versionRange)) {
         throw new Error(
-          `The external dependency ${JSON.stringify(
-            externalName,
-          )} in the required version range ${JSON.stringify(
+          `The external dependency ${JSON.stringify(externalName)} ${
+            consumerId
+              ? `as required by ${JSON.stringify(consumerId)} in the`
+              : `in the required`
+          } version range ${JSON.stringify(
             versionRange,
           )} is not satisfied. The provided version is ${JSON.stringify(
             providedVersion,

--- a/packages/core/src/feature-app-manager.ts
+++ b/packages/core/src/feature-app-manager.ts
@@ -433,7 +433,7 @@ export class FeatureAppManager {
     featureAppId: string,
     options: FeatureAppScopeOptions<TFeatureServices, TConfig>,
   ): FeatureAppRetainer<TFeatureApp> {
-    this.validateExternals(featureAppDefinition);
+    this.validateExternals(featureAppDefinition, featureAppId);
 
     const {
       featureAppName,
@@ -512,6 +512,7 @@ export class FeatureAppManager {
 
   private validateExternals(
     featureAppDefinition: FeatureServiceConsumerDefinition,
+    featureAppId: string,
   ): void {
     const {externalsValidator} = this.options;
 
@@ -522,7 +523,7 @@ export class FeatureAppManager {
     const {dependencies} = featureAppDefinition;
 
     if (dependencies && dependencies.externals) {
-      externalsValidator.validate(dependencies.externals);
+      externalsValidator.validate(dependencies.externals, featureAppId);
     }
   }
 }

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -330,7 +330,7 @@ export class FeatureServiceRegistry {
       return;
     }
 
-    this.validateExternals(providerDefinition);
+    this.validateExternals(providerDefinition, providerId);
 
     const {featureServices} = this.bindFeatureServices(
       providerDefinition,
@@ -434,7 +434,8 @@ export class FeatureServiceRegistry {
   }
 
   private validateExternals(
-    featureAppDefinition: FeatureServiceConsumerDefinition,
+    consumerDefinition: FeatureServiceConsumerDefinition,
+    consumerId: string,
   ): void {
     const {externalsValidator} = this.options;
 
@@ -442,10 +443,10 @@ export class FeatureServiceRegistry {
       return;
     }
 
-    const {dependencies} = featureAppDefinition;
+    const {dependencies} = consumerDefinition;
 
     if (dependencies && dependencies.externals) {
-      externalsValidator.validate(dependencies.externals);
+      externalsValidator.validate(dependencies.externals, consumerId);
     }
   }
 


### PR DESCRIPTION
This is especially useful if the externals validator is replaced by a custom one that needs the consumer info for logging purposes.