### PR TITLE
fix(all): use `import`/`require` instead of `default` in `exports`

### DIFF
--- a/packages/async-ssr-manager/package.json
+++ b/packages/async-ssr-manager/package.json
@@ -30,7 +30,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -35,7 +35,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/history-service/package.json
+++ b/packages/history-service/package.json
@@ -39,7 +39,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/module-loader-amd/package.json
+++ b/packages/module-loader-amd/package.json
@@ -32,7 +32,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/module-loader-commonjs/package.json
+++ b/packages/module-loader-commonjs/package.json
@@ -32,7 +32,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/module-loader-federation/package.json
+++ b/packages/module-loader-federation/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/serialized-state-manager/package.json
+++ b/packages/serialized-state-manager/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {

--- a/packages/server-request/package.json
+++ b/packages/server-request/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "@feature-hub:bundler": "./src/index.ts",
-      "default": "./lib/esm/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "typedoc": {


### PR DESCRIPTION
The `"exports"` field takes precedence over the `"main"` field (see https://nodejs.org/api/packages.html#package-entry-points). So when a feature hub module is required in Node.js, we need to make sure to include the CJS entries in the conditional exports. Otherwise Node.js would fail to require the default ESM entries (`SyntaxError: Unexpected token 'export'`).