### PR TITLE
fix(module-loader-amd): use `__esModule` as default condition

### DIFF
--- a/packages/module-loader-amd/src/index.ts
+++ b/packages/module-loader-amd/src/index.ts
@@ -32,14 +32,7 @@ export function defineExternals(externals: Externals): void {
 export async function loadAmdModule(url: string): Promise<unknown> {
   const module = await System.import(normalizeUrlForSystemJs(url));
 
-  // After being imported by SystemJS, some AMD bundles (dependent on the
-  // bundler that was used) have a `default` property that is also the module
-  // (which itself has the actual default export, i.e.
-  // `module.default.default`). Luckily, SystemJS uses `Symbol.toStringTag` to
-  // tag modules, so we can identify and handle this scenario.
-  return Object.prototype.toString.call(module.default) === '[object Module]'
-    ? module.default
-    : module;
+  return module.__esModule ? module.default : module;
 }
 
 function normalizeUrlForSystemJs(url: string): string {


### PR DESCRIPTION
Turns out, #772 did not cover all cases. When a Feature App is build with Webpack and the babel loader, it looks like this:

<img width="297" alt="build with webpack and babel" src="https://github.com/sinnerschrader/feature-hub/assets/761683/405202fe-b89e-4c1f-aef8-6020a9964495">

This case is not covered by our previous check whether `default` is a `Module`. Instead, we now do what Webpack (among others) does, and look for the presence of the `__esModule` property to decide whether to use `module.default` or `module`.