### PR TITLE
feat(core): add `getInfo` method to feature service registry

### DIFF
--- a/packages/core/src/__tests__/feature-service-registry.test.ts
+++ b/packages/core/src/__tests__/feature-service-registry.test.ts
@@ -861,6 +861,36 @@ describe('FeatureServiceRegistry', () => {
     });
   });
 
+  describe('#getInfo', () => {
+    it('returns info about consumers and registered feature services', () => {
+      featureServiceRegistry = new FeatureServiceRegistry({logger});
+
+      providerDefinitionB = {
+        id: 'b',
+        dependencies: {featureServices: {a: '^1.0.0'}},
+        create: jest.fn(() => ({'1.0.0': binderB, '2.0.0': binderB})),
+      };
+
+      featureServiceRegistry.registerFeatureServices(
+        [providerDefinitionA, providerDefinitionB],
+        'test',
+      );
+
+      featureServiceRegistry.bindFeatureServices(
+        {dependencies: {featureServices: {a: '1.0.0'}}},
+        'foo',
+      );
+
+      expect(featureServiceRegistry.getInfo()).toEqual({
+        consumerIds: ['a', 'b', 'foo'],
+        featureServices: [
+          {id: 'a', versions: ['1.1.0']},
+          {id: 'b', versions: ['1.0.0', '2.0.0']},
+        ],
+      });
+    });
+  });
+
   describe('without a custom logger', () => {
     let consoleInfoSpy: jest.SpyInstance;
 

--- a/packages/core/src/feature-service-registry.ts
+++ b/packages/core/src/feature-service-registry.ts
@@ -90,6 +90,14 @@ export interface FeatureServicesBinding<
   unbind(): void;
 }
 
+export interface FeatureServiceRegistryInfo {
+  readonly consumerIds: string[];
+  readonly featureServices: {
+    readonly id: string;
+    readonly versions: string[];
+  }[];
+}
+
 export interface FeatureServiceRegistryOptions {
   /**
    * If the [[FeatureAppManager]] is configured with a
@@ -309,6 +317,21 @@ export class FeatureServiceRegistry {
     };
 
     return {featureServices, unbind};
+  }
+
+  /**
+   * Returns info about consumers and registered feature services.
+   */
+  public getInfo(): FeatureServiceRegistryInfo {
+    return {
+      consumerIds: Array.from(this.consumerIds),
+      featureServices: [...this.sharedFeatureServices.entries()].map(
+        ([id, sharedFeatureService]) => ({
+          id,
+          versions: Object.keys(sharedFeatureService),
+        }),
+      ),
+    };
   }
 
   private registerFeatureService(


### PR DESCRIPTION
This method is useful when you want to log the currently registered feature services with their provided versions.