### PR TITLE
feat(react): handle cleanup of DOM feature app on it's removal

### DIFF
--- a/docs/guides/writing-a-feature-app.md
+++ b/docs/guides/writing-a-feature-app.md
@@ -235,6 +235,34 @@ const myFeatureAppDefinition = {
 };
 ```
 
+The `attachTo` method of a DOM Feature App can optionally return a "detach"
+function. This function is invoked when the Feature App is removed from the DOM,
+allowing it to perform necessary cleanup tasks (e.g. unsubscribing from events).
+This behavior is similar to how the `useEffect` hook works in React.
+
+```js
+const myFeatureAppDefinition = {
+  create(env) {
+    return {
+      attachTo(container) {
+        const app = Vue.createApp({
+          template: '<div>Hello world!</div>',
+        });
+        app.mount(container);
+
+        return function () {
+          // unsubscribe from events
+          window.removeEventListener('resize', handleResize);
+
+          // or unmount apps
+          app.unmount();
+        };
+      },
+    };
+  },
+};
+```
+
 ### Loading UIs provided by the React Integrator
 
 Both kinds of Feature Apps can specify a loading stage for Feature Apps, which

--- a/packages/demos/src/integrator-dom/feature-app.ts
+++ b/packages/demos/src/integrator-dom/feature-app.ts
@@ -6,7 +6,7 @@ const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
     attachTo(element: HTMLElement): DetachFunction {
       element.replaceWith('Hello, World!');
 
-      return function () {
+      return () => {
         document.title = 'Detached!';
       };
     },

--- a/packages/demos/src/integrator-dom/feature-app.ts
+++ b/packages/demos/src/integrator-dom/feature-app.ts
@@ -1,10 +1,14 @@
 import {FeatureAppDefinition} from '@feature-hub/core';
-import {DomFeatureApp} from '@feature-hub/dom';
+import {DetachFunction, DomFeatureApp} from '@feature-hub/dom';
 
 const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
   create: () => ({
-    attachTo(element: HTMLElement): void {
+    attachTo(element: HTMLElement): DetachFunction {
       element.replaceWith('Hello, World!');
+
+      return function () {
+        document.title = 'Detached!';
+      };
     },
   }),
 };

--- a/packages/demos/src/integrator-dom/index.test.ts
+++ b/packages/demos/src/integrator-dom/index.test.ts
@@ -102,4 +102,20 @@ describe('integration test: "dom integrator"', () => {
       expect(slotName).toBe('loading');
     });
   });
+
+  describe('Feature app has a cleanup function on detach', () => {
+    // const content = await page.evaluate(
+    it('cleanup function gets called when container is removed from DOM', async () => {
+      const title = await page.evaluate(() => {
+        document
+          .querySelector('feature-app-loader')
+          ?.shadowRoot?.querySelector('feature-app-container')
+          ?.remove();
+
+        return document.title;
+      });
+
+      expect(title).toMatch('Detached!');
+    });
+  });
 });

--- a/packages/demos/src/integrator-dom/index.test.ts
+++ b/packages/demos/src/integrator-dom/index.test.ts
@@ -104,7 +104,6 @@ describe('integration test: "dom integrator"', () => {
   });
 
   describe('Feature app has a cleanup function on detach', () => {
-    // const content = await page.evaluate(
     it('cleanup function gets called when container is removed from DOM', async () => {
       const title = await page.evaluate(() => {
         document

--- a/packages/demos/src/todomvc/header/todomvc-header.ts
+++ b/packages/demos/src/todomvc/header/todomvc-header.ts
@@ -7,7 +7,7 @@ export class TodoMvcHeader implements DomFeatureApp {
 
   public constructor(private readonly todoManager: TodoManagerV1) {}
 
-  public attachTo(container: Element): void {
+  public attachTo(container: Element): undefined {
     const header = html`
       <header class="header">
         <h1>todos</h1>

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -8,6 +8,12 @@ import {LitElement, html, property} from 'lit-element';
 import {TemplateResult} from 'lit-html';
 
 /**
+ * Optional detach function to be called on unmount to provide cleanup, e.g.
+ * to avoid memory leaks.
+ */
+export type DetachFunction = () => void;
+
+/**
  * A DOM Feature App allows the use of any frontend technology such as Vue.js,
  * React, or Angular.
  */
@@ -16,7 +22,7 @@ export interface DomFeatureApp {
    * @param container The container element to which the Feature App can attach
    * itself.
    */
-  attachTo(container: Element): void;
+  attachTo(container: Element): void | DetachFunction;
 }
 
 /**
@@ -110,6 +116,8 @@ export function defineFeatureAppContainer(
 
     private readonly appElement = document.createElement('div');
 
+    private detachFunction: DetachFunction | void = void 0;
+
     public firstUpdated(): void {
       if (!this.featureAppDefinition) {
         return;
@@ -126,7 +134,9 @@ export function defineFeatureAppContainer(
           },
         );
 
-        this.featureAppScope.featureApp.attachTo(this.appElement);
+        this.detachFunction = this.featureAppScope.featureApp.attachTo(
+          this.appElement,
+        );
       } catch (error) {
         logger.error(error);
 
@@ -145,6 +155,9 @@ export function defineFeatureAppContainer(
     public disconnectedCallback(): void {
       if (this.featureAppScope) {
         this.featureAppScope.release();
+      }
+      if (this.detachFunction && typeof this.detachFunction === 'function') {
+        this.detachFunction();
       }
 
       super.disconnectedCallback();

--- a/packages/dom/src/feature-app-container.ts
+++ b/packages/dom/src/feature-app-container.ts
@@ -22,7 +22,7 @@ export interface DomFeatureApp {
    * @param container The container element to which the Feature App can attach
    * itself.
    */
-  attachTo(container: Element): void | DetachFunction;
+  attachTo(container: Element): DetachFunction | undefined;
 }
 
 /**
@@ -116,7 +116,7 @@ export function defineFeatureAppContainer(
 
     private readonly appElement = document.createElement('div');
 
-    private detachFunction: DetachFunction | void = void 0;
+    private detachFunction: DetachFunction | undefined = void 0;
 
     public firstUpdated(): void {
       if (!this.featureAppDefinition) {

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -1296,6 +1296,70 @@ describe('FeatureAppContainer', () => {
           });
         });
       });
+
+      describe('when detach function is declared as return in attachTo', () => {
+        let mockDetach: jest.Mock;
+
+        beforeEach(() => {
+          mockDetach = jest.fn();
+
+          mockFeatureAppScope = {
+            featureApp: {
+              attachTo(container: HTMLElement) {
+                container.innerHTML = 'This is the DOM Feature App.';
+                return mockDetach;
+              },
+            },
+            release: jest.fn(),
+          };
+        });
+
+        it('calls the detach function on unmount', () => {
+          const testRenderer = renderWithFeatureHubContext(
+            <FeatureAppContainer
+              featureAppId="testId"
+              featureAppDefinition={mockFeatureAppDefinition}
+            />,
+            {testRendererOptions: {createNodeMock: () => ({})}},
+          );
+
+          expect(mockDetach).not.toHaveBeenCalled();
+
+          testRenderer.unmount();
+
+          expect(mockDetach).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles error in the detach function', () => {
+          const onError = jest.fn();
+          const mockError = new Error('Failed to do a detach cleanup');
+
+          mockFeatureAppScope = {
+            ...mockFeatureAppScope,
+            featureApp: {
+              attachTo: (container: HTMLElement) => {
+                container.innerHTML = 'This is the DOM Feature App.';
+                return () => {
+                  throw mockError;
+                };
+              },
+            },
+          };
+
+          const testRenderer = renderWithFeatureHubContext(
+            <FeatureAppContainer
+              featureAppId="testId"
+              featureAppDefinition={mockFeatureAppDefinition}
+              onError={onError}
+            />,
+            {testRendererOptions: {createNodeMock: () => ({})}},
+          );
+
+          testRenderer.unmount();
+
+          expect(onError.mock.calls).toEqual([[mockError]]);
+        });
+      });
     });
   });
 

--- a/packages/react/src/__tests__/feature-app-container.test.tsx
+++ b/packages/react/src/__tests__/feature-app-container.test.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 import {
   CustomFeatureAppRenderingParams,
+  DetachFunction,
   FeatureApp,
   FeatureAppContainer,
   FeatureHubContextProvider,
@@ -1305,8 +1306,9 @@ describe('FeatureAppContainer', () => {
 
           mockFeatureAppScope = {
             featureApp: {
-              attachTo(container: HTMLElement) {
+              attachTo(container: HTMLElement): DetachFunction {
                 container.innerHTML = 'This is the DOM Feature App.';
+
                 return mockDetach;
               },
             },
@@ -1339,6 +1341,7 @@ describe('FeatureAppContainer', () => {
             featureApp: {
               attachTo: (container: HTMLElement) => {
                 container.innerHTML = 'This is the DOM Feature App.';
+
                 return () => {
                   throw mockError;
                 };

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -47,7 +47,7 @@ export interface DomFeatureApp extends BaseFeatureApp {
    * @param container The container element to which the Feature App can attach
    * itself.
    */
-  attachTo(container: Element): void | DetachFunction;
+  attachTo(container: Element): DetachFunction | undefined;
 }
 
 /**

--- a/packages/react/src/feature-app-container.tsx
+++ b/packages/react/src/feature-app-container.tsx
@@ -33,6 +33,12 @@ export interface ReactFeatureApp extends BaseFeatureApp {
 }
 
 /**
+ * Optional detach function to be called on unmount to provide cleanup, e.g.
+ * to avoid memory leaks.
+ */
+export type DetachFunction = () => void;
+
+/**
  * A DOM Feature App allows the use of other frontend technologies such as
  * Vue.js or Angular, although it is placed on a web page using React.
  */
@@ -41,7 +47,7 @@ export interface DomFeatureApp extends BaseFeatureApp {
    * @param container The container element to which the Feature App can attach
    * itself.
    */
-  attachTo(container: Element): void;
+  attachTo(container: Element): void | DetachFunction;
 }
 
 /**


### PR DESCRIPTION
Hi! First thanks a lot for this amazing library. It allowed us to greatly scale frontend development at Jamf.

We would like to suggest a possibility to do a cleanup when `feature-app-container` is disconnected from the DOM, in order to avoid memory leaks.

Here I present a suggestion that uses a return function in `attachTo` in a similar fashion how "useEffect" works in React. The benefit is access to variables declared inside the `attachTo` scope.

Another solution could be a `detachFrom` function that can be an optional fn on `DomFeatureApp` interface.

Example for React:
```tsx
const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
  dependencies: {
    featureServices: {},
  },
  create: (env: FeatureAppEnvironment<FeatureServices, Config>) => {
    return {
      attachTo(element: HTMLElement): void {
        reactRoot = createRoot(element);
        reactRoot.render(<div>Hello world!</div>);

        return () => {
          reactRoot.unmount();
        };
      },
    };
  },
};
```

Or Vue:
```ts
const featureAppDefinition: FeatureAppDefinition<DomFeatureApp> = {
  dependencies: {
    featureServices: {},
  },
  create: (env: FeatureAppEnvironment<FeatureServices, Config>) => {
    return {
      attachTo(element: HTMLElement): void {
        const app = Vue.createApp({
          template: '<div>Hello world!</div>',
        });
        app.mount('#app');

        return () => {
           app.unmount();
        };
      },
    };
  },
};
```