### PR TITLE
feat(async-ssr-manager): add option ignoring render failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/website/i18n
 todo.tasks
 yarn-error.log
 tsconfig.tsbuildinfo
+.idea

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,7 +4,7 @@ module.exports = [
   {
     name: 'async-ssr-manager',
     path: 'packages/async-ssr-manager/lib/esm/index.js',
-    limit: '0.7 KB',
+    limit: '0.8 KB',
     import: '*',
     modifyWebpackConfig: (config) => ({...config, target: 'node'}),
   },

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,7 +4,7 @@ module.exports = [
   {
     name: 'async-ssr-manager',
     path: 'packages/async-ssr-manager/lib/esm/index.js',
-    limit: '0.8 KB',
+    limit: '0.9 KB',
     import: '*',
     modifyWebpackConfig: (config) => ({...config, target: 'node'}),
   },

--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -373,14 +373,23 @@ describe('defineAsyncSsrManager', () => {
       });
 
       describe('when skipRenderError is configured', () => {
+        let consoleErrorSpy: jest.SpyInstance;
+
         beforeEach(() => {
+          consoleErrorSpy = jest.spyOn(console, 'error');
+
           asyncSsrManagerDefinition = defineAsyncSsrManager({
             timeout: 5,
             skipRenderError: true,
           });
 
-          asyncSsrManagerBinder =
-            asyncSsrManagerDefinition.create(mockEnv)!['1.0.0'];
+          asyncSsrManagerBinder = asyncSsrManagerDefinition.create({
+            featureServices: {},
+          })!['1.0.0'];
+        });
+
+        afterEach(() => {
+          consoleErrorSpy.mockRestore();
         });
 
         describe('with an integrator, and a consumer that schedules a rerender with a failing promise', () => {
@@ -408,6 +417,36 @@ describe('defineAsyncSsrManager', () => {
             );
 
             expect(html).toEqual('<div>renderPass: 2</div>');
+          });
+
+          it('logs the error', async () => {
+            const asyncSsrManagerIntegrator =
+              asyncSsrManagerBinder('test:integrator').featureService;
+
+            const asyncSsrManagerConsumer =
+              asyncSsrManagerBinder('test:consumer').featureService;
+
+            let renderPass = 0;
+
+            const renderFn = jest.fn(() => {
+              renderPass += 1;
+
+              if (renderPass === 1) {
+                asyncSsrManagerConsumer.scheduleRerender(
+                  Promise.reject('Some Reason!'),
+                );
+              }
+
+              return `<div>renderPass: ${renderPass}</div>`;
+            });
+
+            await useFakeTimers(async () =>
+              asyncSsrManagerIntegrator.renderUntilCompleted(renderFn),
+            );
+
+            expect(consoleErrorSpy.mock.calls).toEqual([
+              ['Operation 0 failed rendering with reason:', 'Some Reason!'],
+            ]);
           });
         });
       });

--- a/packages/async-ssr-manager/src/__tests__/index.test.ts
+++ b/packages/async-ssr-manager/src/__tests__/index.test.ts
@@ -371,6 +371,46 @@ describe('defineAsyncSsrManager', () => {
           ]);
         });
       });
+
+      describe('when skipRenderError is configured', () => {
+        beforeEach(() => {
+          asyncSsrManagerDefinition = defineAsyncSsrManager({
+            timeout: 5,
+            skipRenderError: true,
+          });
+
+          asyncSsrManagerBinder =
+            asyncSsrManagerDefinition.create(mockEnv)!['1.0.0'];
+        });
+
+        describe('with an integrator, and a consumer that schedules a rerender with a failing promise', () => {
+          it('still resolves successfully with an html string after the second render pass', async () => {
+            const asyncSsrManagerIntegrator =
+              asyncSsrManagerBinder('test:integrator').featureService;
+
+            const asyncSsrManagerConsumer =
+              asyncSsrManagerBinder('test:consumer').featureService;
+
+            let renderPass = 0;
+
+            const renderFn = jest.fn(() => {
+              renderPass += 1;
+
+              if (renderPass === 1) {
+                asyncSsrManagerConsumer.scheduleRerender(Promise.reject());
+              }
+
+              return `<div>renderPass: ${renderPass}</div>`;
+            });
+
+            const html = await useFakeTimers(async () =>
+              asyncSsrManagerIntegrator.renderUntilCompleted(renderFn),
+            );
+
+            expect(html).toEqual('<div>renderPass: 2</div>');
+          });
+        });
+      });
     });
 
     describe('when no Logger Feature Service is provided', () => {

--- a/packages/async-ssr-manager/src/index.ts
+++ b/packages/async-ssr-manager/src/index.ts
@@ -10,6 +10,16 @@ import {createAsyncSsrManagerContext} from './internal/async-ssr-manager-context
 
 export interface AsyncSsrManagerOptions {
   /**
+   * Determines whether a rendering error should be skipped. This is
+   * particularly useful when using `FeatureAppLoader` to prevent rendering
+   * errors from propagating and breaking the React component tree up to
+   * the parent application. If rendering errors are intended to be
+   * handled individually, this option should remain unset.
+   *
+   * @default false
+   */
+  readonly skipRenderError?: boolean;
+  /**
    * Render timeout in milliseconds.
    */
   readonly timeout?: number;
@@ -104,7 +114,7 @@ export function defineAsyncSsrManager(
 
     create: (env) => {
       const context = createAsyncSsrManagerContext(env.featureServices);
-      const asyncSsrManager = new AsyncSsrManager(context, options.timeout);
+      const asyncSsrManager = new AsyncSsrManager(context, options);
 
       return {
         '1.0.0': () => ({featureService: asyncSsrManager}),

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -74,7 +74,21 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
         asyncOperations.clear();
 
         if (skipRenderError) {
-          await Promise.allSettled(asyncOperationsSnapshot);
+          await Promise.allSettled(asyncOperationsSnapshot).then(
+            (settledResults) => {
+              settledResults
+                .filter(
+                  (rejectedResults): rejectedResults is PromiseRejectedResult =>
+                    rejectedResults.status === 'rejected',
+                )
+                .forEach((rejected, index) => {
+                  this.context.logger.error(
+                    `Operation ${index} failed rendering with reason:`,
+                    rejected.reason,
+                  );
+                });
+            },
+          );
         } else {
           await Promise.all(asyncOperationsSnapshot);
         }

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -1,5 +1,5 @@
 import {AsyncLocalStorage} from 'async_hooks';
-import {AsyncSsrManagerV1} from '..';
+import {AsyncSsrManagerOptions, AsyncSsrManagerV1} from '..';
 import {AsyncSsrManagerContext} from './async-ssr-manager-context';
 import {setTimeoutAsync} from './set-timeout-async';
 
@@ -16,7 +16,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
 
   public constructor(
     private readonly context: AsyncSsrManagerContext,
-    private readonly timeout?: number,
+    private readonly options: AsyncSsrManagerOptions,
   ) {}
 
   public async renderUntilCompleted(
@@ -27,7 +27,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     return this.asyncOperationsStorage.run(asyncOperations, async () => {
       const renderPromise = this.renderingLoop(render, asyncOperations);
 
-      if (typeof this.timeout !== 'number') {
+      if (typeof this.options.timeout !== 'number') {
         this.context.logger.warn(
           'No timeout is configured for the Async SSR Manager. This could lead to unexpectedly long render times or, in the worst case, never resolving render calls!',
         );
@@ -35,7 +35,10 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
         return renderPromise;
       }
 
-      return Promise.race([renderPromise, renderingTimeout(this.timeout)]);
+      return Promise.race([
+        renderPromise,
+        renderingTimeout(this.options.timeout),
+      ]);
     });
   }
 
@@ -57,6 +60,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     render: () => Promise<string> | string,
     asyncOperations: Set<Promise<unknown>>,
   ): Promise<string> {
+    const skipRenderError = this.options.skipRenderError ?? false;
     let html = await render();
 
     while (asyncOperations.size > 0) {
@@ -69,7 +73,11 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
 
         asyncOperations.clear();
 
-        await Promise.all(asyncOperationsSnapshot);
+        if (skipRenderError) {
+          await Promise.allSettled(asyncOperationsSnapshot);
+        } else {
+          await Promise.all(asyncOperationsSnapshot);
+        }
       }
 
       html = await render();

--- a/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
+++ b/packages/async-ssr-manager/src/internal/async-ssr-manager.ts
@@ -16,7 +16,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
 
   public constructor(
     private readonly context: AsyncSsrManagerContext,
-    private readonly options: AsyncSsrManagerOptions,
+    private readonly options?: AsyncSsrManagerOptions,
   ) {}
 
   public async renderUntilCompleted(
@@ -27,7 +27,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     return this.asyncOperationsStorage.run(asyncOperations, async () => {
       const renderPromise = this.renderingLoop(render, asyncOperations);
 
-      if (typeof this.options.timeout !== 'number') {
+      if (typeof this.options?.timeout !== 'number') {
         this.context.logger.warn(
           'No timeout is configured for the Async SSR Manager. This could lead to unexpectedly long render times or, in the worst case, never resolving render calls!',
         );
@@ -37,7 +37,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
 
       return Promise.race([
         renderPromise,
-        renderingTimeout(this.options.timeout),
+        renderingTimeout(this.options?.timeout),
       ]);
     });
   }
@@ -60,7 +60,7 @@ export class AsyncSsrManager implements AsyncSsrManagerV1 {
     render: () => Promise<string> | string,
     asyncOperations: Set<Promise<unknown>>,
   ): Promise<string> {
-    const skipRenderError = this.options.skipRenderError ?? false;
+    const skipRenderError = this.options?.skipRenderError ?? false;
     let html = await render();
 
     while (asyncOperations.size > 0) {

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -132,7 +132,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
         ]);
       });
 
-      it('adds the prepended src URL and moduleType for hydration', () => {
+      it('does not add the prepended src URL and moduleType for hydration', () => {
         renderWithFeatureHubContext(
           <FeatureAppLoader
             featureAppId="testId"
@@ -144,10 +144,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           />,
         );
 
-        expect(mockAddUrlForHydration).toHaveBeenCalledWith(
-          'http://example.com/example.js',
-          'a',
-        );
+        expect(mockAddUrlForHydration).not.toHaveBeenCalled();
       });
     });
 
@@ -165,7 +162,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
       ]);
     });
 
-    it('adds the src URL for hydration', () => {
+    it('does not add the src URL for hydration', () => {
       renderWithFeatureHubContext(
         <FeatureAppLoader
           featureAppId="testId"
@@ -174,10 +171,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
         />,
       );
 
-      expect(mockAddUrlForHydration).toHaveBeenCalledWith(
-        'example.js',
-        undefined,
-      );
+      expect(mockAddUrlForHydration).not.toHaveBeenCalled();
     });
 
     describe('with a moduleType prop', () => {
@@ -261,7 +255,30 @@ describe('FeatureAppLoader (on Node.js)', () => {
         expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
       });
 
-      it('adds the src URL for hydration', () => {
+      it('does not add the stylesheets for SSR', () => {
+        try {
+          renderWithFeatureHubContext(
+            <FeatureAppLoader
+              featureAppId="testId"
+              src="example.js"
+              serverSrc="example-node.js"
+              css={[{href: 'foo.css'}]}
+            />,
+          );
+        } catch {}
+
+        expect(mockAddStylesheetsForSsr.mock.calls).toEqual([
+          [
+            [
+              {
+                href: 'foo.css',
+              },
+            ],
+          ],
+        ]);
+      });
+
+      it('does not add the src URL for hydration', () => {
         try {
           renderWithFeatureHubContext(
             <FeatureAppLoader
@@ -272,10 +289,7 @@ describe('FeatureAppLoader (on Node.js)', () => {
           );
         } catch {}
 
-        expect(mockAddUrlForHydration).toHaveBeenCalledWith(
-          'example.js',
-          undefined,
-        );
+        expect(mockAddUrlForHydration).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/react/src/__tests__/feature-app-loader.node.test.tsx
+++ b/packages/react/src/__tests__/feature-app-loader.node.test.tsx
@@ -132,7 +132,16 @@ describe('FeatureAppLoader (on Node.js)', () => {
         ]);
       });
 
-      it('does not add the prepended src URL and moduleType for hydration', () => {
+      it('adds the prepended src URL and moduleType for hydration with synchronously loaded Feature App definition', () => {
+        jest
+          .spyOn(mockFeatureAppManager, 'getAsyncFeatureAppDefinition')
+          .mockReturnValue({
+            value: {
+              id: 'fa-id',
+              create: jest.fn(),
+            },
+          } as unknown as AsyncValue<FeatureAppDefinition<unknown>>);
+
         renderWithFeatureHubContext(
           <FeatureAppLoader
             featureAppId="testId"
@@ -144,11 +153,18 @@ describe('FeatureAppLoader (on Node.js)', () => {
           />,
         );
 
-        expect(mockAddUrlForHydration).not.toHaveBeenCalled();
+        expect(mockAddUrlForHydration).toHaveBeenCalledWith(
+          'http://example.com/example.js',
+          'a',
+        );
       });
     });
 
     it('schedules a rerender on the Async SSR Manager with the feature app definition promise', () => {
+      jest
+        .spyOn(mockFeatureAppManager, 'getAsyncFeatureAppDefinition')
+        .mockReturnValue(mockAsyncFeatureAppDefinition);
+
       renderWithFeatureHubContext(
         <FeatureAppLoader
           featureAppId="testId"
@@ -162,7 +178,16 @@ describe('FeatureAppLoader (on Node.js)', () => {
       ]);
     });
 
-    it('does not add the src URL for hydration', () => {
+    it('adds the src URL for hydration with synchronously loaded Feature App definition', () => {
+      jest
+        .spyOn(mockFeatureAppManager, 'getAsyncFeatureAppDefinition')
+        .mockReturnValue({
+          value: {
+            id: 'fa-id',
+            create: jest.fn(),
+          },
+        } as unknown as AsyncValue<FeatureAppDefinition<unknown>>);
+
       renderWithFeatureHubContext(
         <FeatureAppLoader
           featureAppId="testId"
@@ -171,7 +196,10 @@ describe('FeatureAppLoader (on Node.js)', () => {
         />,
       );
 
-      expect(mockAddUrlForHydration).not.toHaveBeenCalled();
+      expect(mockAddUrlForHydration).toHaveBeenCalledWith(
+        'example.js',
+        undefined,
+      );
     });
 
     describe('with a moduleType prop', () => {
@@ -225,6 +253,10 @@ describe('FeatureAppLoader (on Node.js)', () => {
       });
 
       it('logs the error', () => {
+        jest
+          .spyOn(mockFeatureAppManager, 'getAsyncFeatureAppDefinition')
+          .mockReturnValue(mockAsyncFeatureAppDefinition);
+
         renderWithFeatureHubContext(
           <FeatureAppLoader
             src="example.js"
@@ -255,30 +287,16 @@ describe('FeatureAppLoader (on Node.js)', () => {
         expect(mockAsyncSsrManager.scheduleRerender).not.toHaveBeenCalled();
       });
 
-      it('does not add the stylesheets for SSR', () => {
-        try {
-          renderWithFeatureHubContext(
-            <FeatureAppLoader
-              featureAppId="testId"
-              src="example.js"
-              serverSrc="example-node.js"
-              css={[{href: 'foo.css'}]}
-            />,
-          );
-        } catch {}
+      it('adds the src URL for hydration with synchronously loaded Feature App definition', () => {
+        jest
+          .spyOn(mockFeatureAppManager, 'getAsyncFeatureAppDefinition')
+          .mockReturnValue({
+            value: {
+              id: 'fa-id',
+              create: jest.fn(),
+            },
+          } as unknown as AsyncValue<FeatureAppDefinition<unknown>>);
 
-        expect(mockAddStylesheetsForSsr.mock.calls).toEqual([
-          [
-            [
-              {
-                href: 'foo.css',
-              },
-            ],
-          ],
-        ]);
-      });
-
-      it('does not add the src URL for hydration', () => {
         try {
           renderWithFeatureHubContext(
             <FeatureAppLoader
@@ -289,7 +307,10 @@ describe('FeatureAppLoader (on Node.js)', () => {
           );
         } catch {}
 
-        expect(mockAddUrlForHydration).not.toHaveBeenCalled();
+        expect(mockAddUrlForHydration).toHaveBeenCalledWith(
+          'example.js',
+          undefined,
+        );
       });
     });
   });

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -143,10 +143,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       return;
     }
 
-    if (!inBrowser && addUrlForHydration) {
-      addUrlForHydration(prependBaseUrl(baseUrl, clientSrc), clientModuleType);
-    }
-
     if (!inBrowser && addStylesheetsForSsr) {
       const css = this.prependCssHrefs();
 
@@ -169,6 +165,13 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       this.state = {error};
     } else if (featureAppDefinition) {
       this.state = {featureAppDefinition};
+
+      if (!inBrowser && addUrlForHydration) {
+        addUrlForHydration(
+          prependBaseUrl(baseUrl, clientSrc),
+          clientModuleType,
+        );
+      }
     } else if (!inBrowser && asyncSsrManager) {
       asyncSsrManager.scheduleRerender(loadingPromise);
     }
@@ -183,7 +186,8 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       return;
     }
 
-    const {baseUrl, featureAppManager, src, moduleType} = this.props;
+    const {baseUrl, featureAppManager, src, moduleType, addUrlForHydration} =
+      this.props;
 
     try {
       const featureAppDefinition =
@@ -194,6 +198,10 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
 
       if (this.mounted) {
         this.setState({featureAppDefinition});
+
+        if (!inBrowser && addUrlForHydration) {
+          addUrlForHydration(prependBaseUrl(baseUrl, src), moduleType);
+        }
       }
     } catch (error) {
       try {

--- a/packages/react/src/feature-app-loader.tsx
+++ b/packages/react/src/feature-app-loader.tsx
@@ -186,8 +186,7 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
       return;
     }
 
-    const {baseUrl, featureAppManager, src, moduleType, addUrlForHydration} =
-      this.props;
+    const {baseUrl, featureAppManager, src, moduleType} = this.props;
 
     try {
       const featureAppDefinition =
@@ -198,10 +197,6 @@ class InternalFeatureAppLoader<TConfig = unknown> extends React.PureComponent<
 
       if (this.mounted) {
         this.setState({featureAppDefinition});
-
-        if (!inBrowser && addUrlForHydration) {
-          addUrlForHydration(prependBaseUrl(baseUrl, src), moduleType);
-        }
       }
     } catch (error) {
       try {


### PR DESCRIPTION
solves: https://github.com/feature-hub/feature-hub/issues/786

**Solution**
Resolve the `renderUntilCompleted()` of the `AsyncSsrManager` successfully even when a loadingPromise is rejected, in order to keep the ancestor react tree alive. This behaviour was made configurable via `AsyncSsrManagerOptions`, in order to avoid a breaking change. Furthermore the `addUrlForHydration` is only being called when the SSR loading actually succeeds since the hydration would be pointless without actual SSR markup.

**Notes:**
- avoids a breaking change
- css will not be touched to keep it minimally invasive